### PR TITLE
Bugfix crashing CombineHLT

### DIFF
--- a/TopAnalysis/interface/CombineHLTCppWorker.h
+++ b/TopAnalysis/interface/CombineHLTCppWorker.h
@@ -19,17 +19,12 @@ public:
   ~CombineHLTCppWorker() = default;
 
   void addHLT(TRB flag);
-  void initOutput(TTree *outputTree);
-
-  void resetValues();
   bool analyze();
 
 private:
   std::vector<TRB> in_HLTFlags;
 
 private:
-  bool _doCppOutput = false;
-  bool out_HLTFlag;
   const std::string outName_;
   TFormula formula_;
 

--- a/TopAnalysis/python/CombineHLT.py
+++ b/TopAnalysis/python/CombineHLT.py
@@ -73,4 +73,8 @@ class CombineHLT(Module, object):
         """process event, return True (go to next module) or False (fail, go to next event)"""
         if event._tree._ttreereaderversion > self._ttreereaderversion:
             self.initReaders(event._tree)
-        self.out.fillBranch(self.outName, self.worker.analyze())
+
+        res = self.worker.analyze()
+        self.out.fillBranch(self.outName, res)
+
+        return res

--- a/TopAnalysis/python/CombineHLT.py
+++ b/TopAnalysis/python/CombineHLT.py
@@ -56,8 +56,7 @@ class CombineHLT(Module, object):
         pass
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
-        self.b_out = self.out.branch(self.outName, "O")
-        self.worker.initOutput(self.out.tree())
+        self.out.branch(self.outName, "O")
         self.initReaders(inputTree)
         pass
     def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
@@ -74,4 +73,4 @@ class CombineHLT(Module, object):
         """process event, return True (go to next module) or False (fail, go to next event)"""
         if event._tree._ttreereaderversion > self._ttreereaderversion:
             self.initReaders(event._tree)
-        return self.worker.analyze()
+        self.out.fillBranch(self.outName, self.worker.analyze())

--- a/TopAnalysis/src/CombineHLTCppWorker.cc
+++ b/TopAnalysis/src/CombineHLTCppWorker.cc
@@ -5,19 +5,8 @@
 using namespace std;
 
 CombineHLTCppWorker::CombineHLTCppWorker(const std::string formulaExpr, const std::string outName):
-  outName_(outName), formula_("", formulaExpr.c_str())
+  outName_(outName), formula_(("CombineHLT_"+outName).c_str(), formulaExpr.c_str())
 {
-}
-
-void CombineHLTCppWorker::initOutput(TTree *outputTree){
-  if ( _doCppOutput ) return;
-
-  //if (_doCppOutput) throw cms::Exception("LogicError","doCppOutput cannot be called twice");
-  _doCppOutput = true;
-
-  //outputTree->Branch(outName_.c_str(), &out_HLTFlag, (outName_+"/O").c_str());
-  //outputTree->SetBranchAddress(outName_.c_str(), &out_HLTFlag);
-  outputTree->GetBranch(outName_.c_str())->SetAddress(&out_HLTFlag);
 }
 
 typedef CombineHLTCppWorker::TRB TRB;
@@ -26,13 +15,7 @@ void CombineHLTCppWorker::addHLT(TRB HLTFlag) {
   in_HLTFlags.push_back(HLTFlag);
 }
 
-void CombineHLTCppWorker::resetValues() {
-  out_HLTFlag = false;
-}
-
 bool CombineHLTCppWorker::analyze() {
-  resetValues();
-
   for ( int i=0; i<formula_.GetNpar(); ++i ) {
     formula_.SetParameter(i, static_cast<double>(**in_HLTFlags[i]));
   }


### PR DESCRIPTION
CombineHLT module bugfix
- no more crash
  - give own name to TFormula
  - use the NanoAODTool's branch python interfaces
- correctly save combined results