### PR TITLE
Do not separate SF branches from the "reco" ntuple

### DIFF
--- a/TopAnalysis/test/fcncTriLepton/prod_ntuple/run.sh
+++ b/TopAnalysis/test/fcncTriLepton/prod_ntuple/run.sh
@@ -31,19 +31,16 @@ ARGS="$ARGS -I TZWi.TopAnalysis.fcncTriLepton fcnc$CHANNEL"
 
 OUTPATH=ntuple
 CMD="nano_postproc.py --friend"
-[ ! -d $OUTPATH ] && mkdir -p $OUTPATH
-$CMD $ARGS $OUTPATH/reco $FILENAMES
+[ ! -d $OUTPATH/reco ] && mkdir -p $OUTPATH/reco
 if [ _$DATATYPE1 == "_MC" ]; then
-    [ ! -d $OUTPATH/mc ] && mkdir -p $OUTPATH/mc
-    ARGS=""
     ARGS="$ARGS -I PhysicsTools.NanoAODTools.postprocessing.modules.common.lepSFProducer lepSF"
     ARGS="$ARGS -I PhysicsTools.NanoAODTools.postprocessing.modules.common.puWeightProducer puWeight"
-    $CMD $ARGS $OUTPATH/mc $FILENAMES
+fi
+$CMD $ARGS $OUTPATH/reco $FILENAMES
 
-    if `echo _$DATATYPE3 | grep -q 'TT_'`; then
-        [ ! -d $OUTPATH/mctop ] && mkdir -p $OUTPATH/mctop
-        ARGS="-I TZWi.TopAnalysis.partonTop partonTop"
-        $CMD $ARGS $OUTPATH/mctop $FILENAMES
-    fi
+if `echo _$DATATYPE3 | grep -q 'TT_'`; then
+    [ ! -d $OUTPATH/mctop ] && mkdir -p $OUTPATH/mctop
+    ARGS="-I TZWi.TopAnalysis.partonTop partonTop"
+    $CMD $ARGS $OUTPATH/mctop $FILENAMES
 fi
 

--- a/TopAnalysis/test/ttbarDoubleLepton/prod_ntuple/run.sh
+++ b/TopAnalysis/test/ttbarDoubleLepton/prod_ntuple/run.sh
@@ -32,19 +32,16 @@ ARGS="$ARGS -I TZWi.TopAnalysis.ttbarDoubleLeptonHLT flags_${DATATYPE1}"
 
 OUTPATH=ntuple
 CMD="nano_postproc.py --friend"
-[ ! -d $OUTPATH ] && mkdir -p $OUTPATH
-$CMD $ARGS $OUTPATH/reco $FILENAMES
+[ ! -d $OUTPATH/reco ] && mkdir -p $OUTPATH/reco
 if [ _$DATATYPE1 == "_MC" ]; then
-    [ ! -d $OUTPATH/mc ] && mkdir -p $OUTPATH/mc
-    ARGS=""
     ARGS="$ARGS -I PhysicsTools.NanoAODTools.postprocessing.modules.common.lepSFProducer lepSF"
     ARGS="$ARGS -I PhysicsTools.NanoAODTools.postprocessing.modules.common.puWeightProducer puWeight"
-    $CMD $ARGS $OUTPATH/mc $FILENAMES
+fi
+$CMD $ARGS $OUTPATH/reco $FILENAMES
 
-    if `echo _$DATATYPE3 | grep -q 'TT_'`; then
-        [ ! -d $OUTPATH/mctop ] && mkdir -p $OUTPATH/mctop
-        ARGS="-I TZWi.TopAnalysis.partonTop partonTop"
-        $CMD $ARGS $OUTPATH/mctop $FILENAMES
-    fi
+if `echo _$DATATYPE3 | grep -q 'TT_'`; then
+    [ ! -d $OUTPATH/mctop ] && mkdir -p $OUTPATH/mctop
+    ARGS="-I TZWi.TopAnalysis.partonTop partonTop"
+    $CMD $ARGS $OUTPATH/mctop $FILENAMES
 fi
 


### PR DESCRIPTION
For convenience - have scale factors in the output ntuple.
Still for the moment, generator level top quark objects are kept in a separate ntuple.