### PR TITLE
Steps for parallel-input

### DIFF
--- a/TopAnalysis/python/postprocessing/CopyBranch.py
+++ b/TopAnalysis/python/postprocessing/CopyBranch.py
@@ -36,5 +36,5 @@ class CopyBranch(Module, object):
             self.out.fillBranch(brName, getattr(event, brName))
         return True
 
-copyBranch = lambda: CopyBranch(["PV_npvsGood"])
+copyBranch = lambda: CopyBranch(["run", "event", "PV_npvsGood"])
 

--- a/TopAnalysis/test/fcncTriLepton/01_prod_ntuple.sh
+++ b/TopAnalysis/test/fcncTriLepton/01_prod_ntuple.sh
@@ -31,9 +31,10 @@ FILENAMES=$(cat $FILELIST | xargs -n$MAXFILES | sed -n "$(($JOBNUMBER+1)) p" | s
 
 ARGS=""
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLeptonHLT flags_${DATATYPE}"
-for MODE in E M MM EE ME; do
-    ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLeptonHLT hlt_${MODE}_${DATATYPE}"
-done
+#for MODE in E M MM EE ME; do
+#    ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLeptonHLT hlt_${MODE}_${DATATYPE}"
+#done
+ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLeptonHLT "`echo hlt_{E,M,MM,EE,ME}_${DATATYPE} | tr ' ' ','`
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLepton fcnc_${CHANNEL}"
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLeptonCutFlow cutFlow_${CHANNEL}"
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.CopyBranch copyBranch"


### PR DESCRIPTION
Add run number and event branches - analyzers can correctly associate events through multiple trees.