### PR TITLE
Simplify HLT information in the ntuple

### DIFF
--- a/NanoAODProduction/data/datasets/NanoAOD/2016/MC.RunIISummer16.central.yaml
+++ b/NanoAODProduction/data/datasets/NanoAOD/2016/MC.RunIISummer16.central.yaml
@@ -1,10 +1,4 @@
 dataset:
-    MC2016.DYJetsToLL_M-50:
-        ? /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/NANOAODSIM
-        :   - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/90000
-            - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/40000
-            - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/280000
-            - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/80000
     MC2016.DYJetsToLL_M-10to50:
         ? /DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/NANOAODSIM
         :   - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/40000
@@ -14,12 +8,18 @@ dataset:
         ? /DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext1-v1/NANOAODSIM
         :   - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext1-v1/30000
             - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext1-v1/80000
+    MC2016.DYJetsToLL_M-50:
+        ? /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/NANOAODSIM
+        :   - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/90000
+            - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/40000
+            - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/280000
+            - /store/mc/RunIISummer16NanoAODv4/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext2-v1/80000
     MC2016.ST_s_4f_lepton:
         ? /ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/NANOAODSIM
         :   - /store/mc/RunIISummer16NanoAODv4/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/50000
-    MC2016.STbar_tW:
-        ? /ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext1-v1/NANOAODSIM
-        :   - /store/mc/RunIISummer16NanoAODv4/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext1-v1/30000
+    MC2016.ST_t:
+        ? /ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/NANOAODSIM
+        :   - /store/mc/RunIISummer16NanoAODv4/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/80000
     MC2016.ST_tW:
         ? /ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext1-v1/NANOAODSIM
         :   - /store/mc/RunIISummer16NanoAODv4/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext1-v1/30000
@@ -27,9 +27,9 @@ dataset:
         ? /ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/NANOAODSIM
         :   - /store/mc/RunIISummer16NanoAODv4/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/30000
             - /store/mc/RunIISummer16NanoAODv4/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/280000
-    MC2016.ST_t:
-        ? /ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/NANOAODSIM
-        :   - /store/mc/RunIISummer16NanoAODv4/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/80000
+    MC2016.STbar_tW:
+        ? /ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext1-v1/NANOAODSIM
+        :   - /store/mc/RunIISummer16NanoAODv4/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6_ext1-v1/30000
     MC2016.TTTo2L2Nu:
         ? /TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/RunIISummer16NanoAODv4-PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/NANOAODSIM
         :   - /store/mc/RunIISummer16NanoAODv4/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/NANOAODSIM/PUMoriond17_Nano14Dec2018_102X_mcRun2_asymptotic_v6-v1/90000

--- a/TopAnalysis/data/combineHLT/fcncTriLepton/2016.yaml
+++ b/TopAnalysis/data/combineHLT/fcncTriLepton/2016.yaml
@@ -10,6 +10,18 @@ RunIISummer16.DoubleEG: "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ"
 RunIISummer16.SingleMuon: "HLT_IsoMu24 || HLT_IsoTkMu24"
 RunIISummer16.SingleElectron: "HLT_Ele32_eta2p1_WPTight_Gsf"
 
+RunIISummer16: "
+  HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL || HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_DZ ||
+  HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL || HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ ||
+  HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL || HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL ||
+  HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ || HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ ||
+  HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ ||
+  HLT_IsoMu24 || HLT_IsoTkMu24 ||
+  HLT_Ele32_eta2p1_WPTight_Gsf
+"
+
+#######################
+
 Run2016BE.MuonEG: "
   ( HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL || HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL ) ||
   HLT_Mu8_DiEle12_CaloIdL_TrackIdL || HLT_DiMu9_Ele9_CaloIdL_TrackIdL

--- a/TopAnalysis/data/grouping/fcncTrilepton.yaml
+++ b/TopAnalysis/data/grouping/fcncTrilepton.yaml
@@ -28,20 +28,17 @@ processes:
 
     DYJets:
         title: "Z/#gamma^{*}+Jets#rightarrow l^{+}l^{-}"
-        #weight: "puWeight*BtagWeight"
         weight: "genWeight*puWeight*BtagWeight"
         datasets:
             - MC2016.DYJetsToLL_M-10to50
             - MC2016.DYJetsToLL_M-50
     WJets:
         title: "W+jets"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.WJets]
     SingleTop:
         title: "Single top"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets:
             - MC2016.ST_s_4f_lepton
             - MC2016.ST_t
@@ -50,55 +47,45 @@ processes:
             - MC2016.STbar_tW
     fcncLL:
         title: "t#bar{t}b#bar{b}"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.TTTo2L2Nu]
         #cut: "genTTBBCategory==55"
     ttccLL:
         title: "t#bar{t}cc"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.TTTo2L2Nu]
         #cut: "genTTBBCategory==3"
     ttLFLL:
         title: "t#bar{t}LF"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.TTTo2L2Nu]
         #cut: "genTTBBCategory==0"
     TTOther:
         title: "t#bar{t} others"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.TTToSemilepton, MC2016.TTToHadronic]
     Dibosons:
         title: "Dibosons"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.WW, MC2016.WZ, MC2016.ZZ]
     Tribonsons:
         title: "Tribosons"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.WWW, MC2016.WWZ, MC2016.WZZ, MC2016.ZZZ]
 
     SingleTopV:
         title: "SingleTop+V"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.tZq_ll]
     ttbb:
         title: "t#bar{t}b#bar{b}"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.ttbb]
     TTV:
         title: "t#bar{t}+V"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.TTWJetsToLNu, MC2016.TTWJetsToQQ, MC2016.TTZToLLNuNu, MC2016.TTZToQQ]
     TTH:
         title: "t#bar{t}+Higgs"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2016.ttHToNonbb, MC2016.ttHTobb]

--- a/TopAnalysis/data/grouping/ttbbDilepton.yaml
+++ b/TopAnalysis/data/grouping/ttbbDilepton.yaml
@@ -3,35 +3,28 @@ processes:
         title: "Data"
         datasets:
             - Run2017.DoubleEG
-            - Run2017.SingleElectron
     DataMuMu:
         title: "Data"
         datasets:
             - Run2017.DoubleMuon
-            - Run2017.SingleMuon
     DataMuEl:
         title: "Data"
         datasets:
             - Run2017.MuonEG
-            - Run2017.SingleMuon
-            - Run2017.SingleElectron
 
     DYJets:
         title: "Z/#gamma^{*}+Jets#rightarrow l^{+}l^{-}"
-        #weight: "puWeight*BtagWeight"
         weight: "genWeight*puWeight*BtagWeight"
         datasets:
             - MC2017.DYJetsToLL_M-10to50
             - MC2017.DYJetsToLL_M-50
     WJets:
         title: "W+jets"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.WJets]
     SingleTop:
         title: "Single top"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets:
             - MC2017.ST_s_4f_lepton
             - MC2017.ST_t
@@ -40,61 +33,49 @@ processes:
             - MC2017.STbar_tW
     ttbbLL:
         title: "t#bar{t}b#bar{b}"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.TTTo2L2Nu]
         #cut: "genTTBBCategory==55"
     ttbjLL:
         title: "t#bar{t}bj"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.TTTo2L2Nu]
         #cut: "genTTBBCategory==5"
     ttccLL:
         title: "t#bar{t}cc"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.TTTo2L2Nu]
         #cut: "genTTBBCategory==3"
     ttLFLL:
         title: "t#bar{t}LF"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.TTTo2L2Nu]
         #cut: "genTTBBCategory==0"
     TTOther:
         title: "t#bar{t} others"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.TTToSemilepton, MC2017.TTToHadronic]
     Dibosons:
         title: "Dibosons"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.WW, MC2017.WZ, MC2017.ZZ]
     Tribonsons:
         title: "Tribosons"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.WWW, MC2017.WWZ, MC2017.WZZ, MC2017.ZZZ]
 
     SingleTopV:
         title: "SingleTop+V"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.tZq_ll]
     ttbb:
         title: "t#bar{t}b#bar{b}"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.ttbb]
     TTV:
         title: "t#bar{t}+V"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
+        weight: "genWeight*puWeight*BtagWeight"
         datasets: [MC2017.TTWJetsToLNu, MC2017.TTWJetsToQQ, MC2017.TTZToLLNuNu, MC2017.TTZToQQ]
     TTH:
         title: "t#bar{t}+Higgs"
-        weight: "puWeight*BtagWeight"
-        #weight: "genWeight*puWeight*BtagWeight"
-        datasets: [MC2017.ttHToNonbb, MC2017.ttHTobb]
+        atasets: [MC2017.ttHToNonbb, MC2017.ttHTobb]

--- a/TopAnalysis/data/histogramming/fcncTrilepton.yaml
+++ b/TopAnalysis/data/histogramming/fcncTrilepton.yaml
@@ -1,9 +1,5 @@
 ## Histogramming for tcZ trilepton analysis
 
-weights:
-    central: "genWeight*puWeight*BtagWeight"
-    noWeight: "genWeight"
-
 steps:
     - name: "S1"
       cuts: ["CutStep >= 1"]
@@ -55,7 +51,7 @@ hists:
     nPV_noWeight:
         title: "nPV_noWeight;Vertex multiplicity;Events (unweighted)"
         expr: "PV_npvsGood"
-        weights: noWeight
+        weightsToDrop: ["pileupWeight", "pileupWeight_up", "pileupWeight_down"]
         bins:
             nbinsX: 100
             xmin: 0

--- a/TopAnalysis/python/postprocessing/fcncTriLeptonHLT.py
+++ b/TopAnalysis/python/postprocessing/fcncTriLeptonHLT.py
@@ -6,30 +6,16 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 
 from TZWi.TopAnalysis.postprocessing.CombineHLT import CombineHLT
 
-hlt_E_MC2016  = lambda : CombineHLT(outName="HLT_E" , fileName="fcncTriLepton/2016.yaml", hltSet="RunIISummer16.SingleElectron")
-hlt_M_MC2016  = lambda : CombineHLT(outName="HLT_M" , fileName="fcncTriLepton/2016.yaml", hltSet="RunIISummer16.SingleMuon")
-hlt_MM_MC2016 = lambda : CombineHLT(outName="HLT_MM", fileName="fcncTriLepton/2016.yaml", hltSet="RunIISummer16.DoubleMuon")
-hlt_EE_MC2016 = lambda : CombineHLT(outName="HLT_EE", fileName="fcncTriLepton/2016.yaml", hltSet="RunIISummer16.DoubleEG")
-hlt_ME_MC2016 = lambda : CombineHLT(outName="HLT_ME", fileName="fcncTriLepton/2016.yaml", hltSet="RunIISummer16.MuonEG")
+hlt_MC2016 = lambda : CombineHLT(fileName="fcncTriLepton/2016.yaml", hltSet="RunIISummer16")
 
-hlt_E_Run2016BE  = lambda : CombineHLT(outName="HLT_E" , fileName="fcncTriLepton/2016.yaml", hltSet="Run2016BE.SingleElectron")
-hlt_M_Run2016BE  = lambda : CombineHLT(outName="HLT_M" , fileName="fcncTriLepton/2016.yaml", hltSet="Run2016BE.SingleMuon")
-hlt_MM_Run2016BE = lambda : CombineHLT(outName="HLT_MM", fileName="fcncTriLepton/2016.yaml", hltSet="Run2016BE.DoubleMuon")
-hlt_EE_Run2016BE = lambda : CombineHLT(outName="HLT_EE", fileName="fcncTriLepton/2016.yaml", hltSet="Run2016BE.DoubleEG")
-hlt_ME_Run2016BE = lambda : CombineHLT(outName="HLT_ME", fileName="fcncTriLepton/2016.yaml", hltSet="Run2016BE.MuonEG")
+for dataset in ['SingleMuon', 'SingleElectron',
+                'DoubleMuon', 'DoubleEG', 'MuonEG']:
+    for e in "BCDE":
+        vars()['hlt_Run2016%s_%s' % (e, dataset)] = lambda : CombineHLT(fileName="fcncTriLepton/2016.yaml", hltSet="Run2016BE.%s" % dataset, doFilter=True)
+    for e in "FG":
+        vars()['hlt_Run2016%s_%s' % (e, dataset)] = lambda : CombineHLT(fileName="fcncTriLepton/2016.yaml", hltSet="Run2016FG.%s" % dataset, doFilter=True)
+    vars()['hlt_Run2016H_%s'  % dataset] = lambda : CombineHLT(fileName="fcncTriLepton/2016.yaml", hltSet="Run2016H.%s"  % dataset, doFilter=True)
 
-hlt_E_Run2016FG  = lambda : CombineHLT(outName="HLT_E" , fileName="fcncTriLepton/2016.yaml", hltSet="Run2016FG.SingleElectron")
-hlt_M_Run2016FG  = lambda : CombineHLT(outName="HLT_M" , fileName="fcncTriLepton/2016.yaml", hltSet="Run2016FG.SingleMuon")
-hlt_MM_Run2016FG = lambda : CombineHLT(outName="HLT_MM", fileName="fcncTriLepton/2016.yaml", hltSet="Run2016FG.DoubleMuon")
-hlt_EE_Run2016FG = lambda : CombineHLT(outName="HLT_EE", fileName="fcncTriLepton/2016.yaml", hltSet="Run2016FG.DoubleEG")
-hlt_ME_Run2016FG = lambda : CombineHLT(outName="HLT_ME", fileName="fcncTriLepton/2016.yaml", hltSet="Run2016FG.MuonEG")
-
-hlt_E_Run2016H  = lambda : CombineHLT(outName="HLT_E" , fileName="fcncTriLepton/2016.yaml", hltSet="Run2016H.SingleElectron")
-hlt_M_Run2016H  = lambda : CombineHLT(outName="HLT_M" , fileName="fcncTriLepton/2016.yaml", hltSet="Run2016H.SingleMuon")
-hlt_MM_Run2016H = lambda : CombineHLT(outName="HLT_MM", fileName="fcncTriLepton/2016.yaml", hltSet="Run2016H.DoubleMuon")
-hlt_EE_Run2016H = lambda : CombineHLT(outName="HLT_EE", fileName="fcncTriLepton/2016.yaml", hltSet="Run2016H.DoubleEG")
-hlt_ME_Run2016H = lambda : CombineHLT(outName="HLT_ME", fileName="fcncTriLepton/2016.yaml", hltSet="Run2016H.MuonEG")
-
-flags_MC2016 = lambda : CombineHLT(outName="Flag", fileName="flags/2016.yaml", hltSet="RunIISummer16")
-flags_Run2016 = lambda : CombineHLT(outName="Flag", fileName="flags/2016.yaml", hltSet="Run2016")
+flags_MC2016 = lambda : CombineHLT(outName="Flag", fileName="flags/2016.yaml", hltSet="RunIISummer16", doFilter=True)
+flags_Run2016 = lambda : CombineHLT(outName="Flag", fileName="flags/2016.yaml", hltSet="Run2016", doFilter=True)
 

--- a/TopAnalysis/python/postprocessing/ttbarDoubleLeptonHLT.py
+++ b/TopAnalysis/python/postprocessing/ttbarDoubleLeptonHLT.py
@@ -6,29 +6,31 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 
 from TZWi.TopAnalysis.postprocessing.CombineHLT import CombineHLT
 
-hlt_MuMu_MC2016 = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="RunIISummer16.DoubleMuon", doFilter=True)
-hlt_ElEl_MC2016 = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="RunIISummer16.DoubleEG", doFilter=True)
-hlt_MuEl_MC2016 = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="RunIISummer16.MuonEG", doFilter=True)
+hlt_MC2016_MuMu = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="RunIISummer16.DoubleMuon", doFilter=True)
+hlt_MC2016_ElEl = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="RunIISummer16.DoubleEG", doFilter=True)
+hlt_MC2016_MuEl = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="RunIISummer16.MuonEG", doFilter=True)
 
-hlt_MuMu_MC2017 = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="RunIIFall17.DoubleMuon", doFilter=True)
-hlt_ElEl_MC2017 = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="RunIIFall17.DoubleEG", doFilter=True)
-hlt_MuEl_MC2017 = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="RunIIFall17.MuonEG", doFilter=True)
+hlt_MC2017_MuMu = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="RunIIFall17.DoubleMuon", doFilter=True)
+hlt_MC2017_ElEl = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="RunIIFall17.DoubleEG", doFilter=True)
+hlt_MC2017_MuEl = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="RunIIFall17.MuonEG", doFilter=True)
 
-hlt_MuMu_Run2016BG = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016BG.DoubleMuon", doFilter=True)
-hlt_ElEl_Run2016BG = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016BG.DoubleEG", doFilter=True)
-hlt_MuEl_Run2016BG = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016BG.MuonEG", doFilter=True)
+for e in "BCDEFG":
+    vars()["hlt_Run2016%s_MuMu" % e] = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016BG.DoubleMuon", doFilter=True)
+    vars()["hlt_Run2016%s_ElEl" % e] = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016BG.DoubleEG", doFilter=True)
+    vars()["hlt_Run2016%s_MuEl" % e] = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016BG.MuonEG", doFilter=True)
 
-hlt_MuMu_Run2016H = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016H.DoubleMuon", doFilter=True)
-hlt_ElEl_Run2016H = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016H.DoubleEG", doFilter=True)
-hlt_MuEl_Run2016H = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016H.MuonEG", doFilter=True)
+hlt_Run2016H_MuMu = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016H.DoubleMuon", doFilter=True)
+hlt_Run2016H_ElEl = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016H.DoubleEG", doFilter=True)
+hlt_Run2016H_MuEl = lambda : CombineHLT(fileName="ttbarDoubleLepton/2016.yaml", hltSet="Run2016H.MuonEG", doFilter=True)
 
-hlt_MuMu_Run2017B = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017B.DoubleMuon", doFilter=True)
-hlt_ElEl_Run2017B = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017B.DoubleEG", doFilter=True)
-hlt_MuEl_Run2017B = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017B.MuonEG", doFilter=True)
+hlt_Run2017B_MuMu = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017B.DoubleMuon", doFilter=True)
+hlt_Run2017B_ElEl = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017B.DoubleEG", doFilter=True)
+hlt_Run2017B_MuEl = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017B.MuonEG", doFilter=True)
 
-hlt_MuMu_Run2017CF = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017CF.DoubleMuon", doFilter=True)
-hlt_ElEl_Run2017CF = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017CF.DoubleEG", doFilter=True)
-hlt_MuEl_Run2017CF = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017CF.MuonEG", doFilter=True)
+for e in "CDEF":
+    vars()["hlt_Run2017%s_MuMu" % e] = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017CF.DoubleMuon", doFilter=True)
+    vars()["hlt_Run2017%s_ElEl" % e] = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017CF.DoubleEG", doFilter=True)
+    vars()["hlt_Run2017%s_MuEl" % e] = lambda : CombineHLT(fileName="ttbarDoubleLepton/2017.yaml", hltSet="Run2017CF.MuonEG", doFilter=True)
 
 flags_MC2016 = lambda : CombineHLT(outName="Flag", fileName="flags/2016.yaml", hltSet="RunIISummer16", doFilter=True)
 flags_Run2016 = lambda : CombineHLT(outName="Flag", fileName="flags/2016.yaml", hltSet="Run2016", doFilter=True)

--- a/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
+++ b/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
@@ -105,8 +105,8 @@ bool FCNCTriLeptonCppWorker::isGoodElectron(const unsigned i) const {
   const double pt = in_Electrons_p4[0]->At(i);
   const double eta = in_Electrons_p4[1]->At(i);
   if ( pt < minElectronPt_ or std::abs(eta) > maxElectronEta_ ) return false;
-  //nanoAOD object -> Electron_cutBased_Sum16 0:fail, 1:veto, 2:medium, 3:tight
-  if ( in_Electrons_id->At(i) != 3 ) return false;
+  //nanoAOD object -> Electron_cutBased_Sum16 0:fail, 1:veto, 2:loose, 3:medium, 4:tight
+  if ( in_Electrons_id->At(i) != 4 ) return false;
 
   return true;
 }
@@ -115,7 +115,7 @@ bool FCNCTriLeptonCppWorker::isVetoElectron(const unsigned i) const {
   const double pt = in_Electrons_p4[0]->At(i);
   const double eta = in_Electrons_p4[1]->At(i);
   if ( pt < minElectronPt_ or std::abs(eta) > maxElectronEta_ ) return false;
-  //nanoAOD object -> Electron_cutBased_Sum16 0:fail, 1:veto, 2:medium, 3:tight
+  //nanoAOD object -> Electron_cutBased_Sum16 0:fail, 1:veto, 2:loose, 3:medium, 4:tight
   if ( in_Electrons_id->At(i) == 0 ) return false;
 
   return true;

--- a/TopAnalysis/src/TTbarDoubleLeptonCppWorker.cc
+++ b/TopAnalysis/src/TTbarDoubleLeptonCppWorker.cc
@@ -87,7 +87,7 @@ bool TTbarDoubleLeptonCppWorker::isGoodMuon(const unsigned i) const {
 }
 
 bool TTbarDoubleLeptonCppWorker::isGoodElectron(const unsigned i) const {
-  const double pt = in_Electrons_p4[0]->At(i) * in_Electrons_eCorr->At(i);
+  const double pt = in_Electrons_p4[0]->At(i);
   const double eta = in_Electrons_p4[1]->At(i);
   if ( pt < minLepton2Pt_ or std::abs(eta) > maxLepton2Eta_ ) return false;
   if ( in_Electrons_id->At(i) <= 1 ) return false;
@@ -133,19 +133,19 @@ bool TTbarDoubleLeptonCppWorker::analyze() {
   int electron1Idx = -1, electron2Idx = -1;
   int nGoodElectrons = 0;
   for ( unsigned i=0, n=in_Electrons_p4[0]->GetSize(); i<n; ++i ) {
-    const double pt = in_Electrons_p4[0]->At(i) * in_Electrons_eCorr->At(i);
+    const double pt = in_Electrons_p4[0]->At(i);
     if ( isGoodElectron(i) ) {
       ++nGoodElectrons;
-      if ( electron2Idx < 0 or pt > in_Electrons_p4[0]->At(electron2Idx) * in_Electrons_eCorr->At(electron2Idx) ) electron2Idx = i;
-      if ( electron1Idx < 0 or pt > in_Electrons_p4[0]->At(electron1Idx) * in_Electrons_eCorr->At(electron1Idx) ) std::swap(electron1Idx, electron2Idx);
+      if ( electron2Idx < 0 or pt > in_Electrons_p4[0]->At(electron2Idx) ) electron2Idx = i;
+      if ( electron1Idx < 0 or pt > in_Electrons_p4[0]->At(electron1Idx) ) std::swap(electron1Idx, electron2Idx);
     }
   }
 
   // Select event by decay mode
   auto actualMode = mode_;
   if ( mode_ == MODE::Auto ) {
-    if      ( muon1Idx     == -1 or in_Muons_p4[0]->At(muon1Idx) < in_Electrons_p4[0]->At(electron2Idx) * in_Electrons_eCorr->At(electron2Idx) ) actualMode = MODE::ElEl;
-    else if ( electron1Idx == -1 or in_Electrons_p4[0]->At(electron1Idx) *  in_Electrons_eCorr->At(electron1Idx) < in_Muons_p4[0]->At(muon2Idx) ) actualMode = MODE::MuMu;
+    if      ( muon1Idx     == -1 or in_Muons_p4[0]->At(muon1Idx) < in_Electrons_p4[0]->At(electron2Idx) ) actualMode = MODE::ElEl;
+    else if ( electron1Idx == -1 or in_Electrons_p4[0]->At(electron1Idx) < in_Muons_p4[0]->At(muon2Idx) ) actualMode = MODE::MuMu;
     else actualMode = MODE::MuEl;
   }
 
@@ -159,8 +159,8 @@ bool TTbarDoubleLeptonCppWorker::analyze() {
   }
   else if ( actualMode == MODE::ElEl ) {
     for ( unsigned i=0; i<4; ++i ) {
-      if ( electron1Idx >= 0 ) out_Lepton1_p4[i] = in_Electrons_p4[i]->At(electron1Idx) * in_Electrons_eCorr->At(electron1Idx);
-      if ( electron2Idx >= 0 ) out_Lepton2_p4[i] = in_Electrons_p4[i]->At(electron2Idx) * in_Electrons_eCorr->At(electron2Idx);
+      if ( electron1Idx >= 0 ) out_Lepton1_p4[i] = in_Electrons_p4[i]->At(electron1Idx);
+      if ( electron2Idx >= 0 ) out_Lepton2_p4[i] = in_Electrons_p4[i]->At(electron2Idx);
     }
     if ( electron1Idx >= 0 ) out_Lepton1_pdgId = -11*in_Electrons_charge->At(electron1Idx);
     if ( electron2Idx >= 0 ) out_Lepton2_pdgId = -11*in_Electrons_charge->At(electron2Idx);
@@ -168,7 +168,7 @@ bool TTbarDoubleLeptonCppWorker::analyze() {
   else if ( actualMode == MODE::MuEl ) {
     for ( unsigned i=0; i<4; ++i ) {
       if ( muon1Idx     >= 0 ) out_Lepton1_p4[i] = in_Muons_p4[i]->At(muon1Idx);
-      if ( electron1Idx >= 0 ) out_Lepton2_p4[i] = in_Electrons_p4[i]->At(electron1Idx) * in_Electrons_eCorr->At(electron1Idx);
+      if ( electron1Idx >= 0 ) out_Lepton2_p4[i] = in_Electrons_p4[i]->At(electron1Idx);
     }
     if ( muon1Idx     >= 0 ) out_Lepton1_pdgId = -13*in_Muons_charge->At(muon1Idx);
     if ( electron1Idx >= 0 ) out_Lepton2_pdgId = -11*in_Electrons_charge->At(electron1Idx);

--- a/TopAnalysis/test/fcncTriLepton/01_prod_ntuple.sh
+++ b/TopAnalysis/test/fcncTriLepton/01_prod_ntuple.sh
@@ -29,28 +29,17 @@ DATASET='/'`echo $DATASET0 | sed -e 's;\.;/;g'`
 ERA=$(echo $DATASET0 | cut -d. -f2 | cut -d- -f1 | sed -e 's;NanoAOD;;g')
 
 DATATYPE=$(basename $(dirname $FILELIST) | cut -d. -f1)
-ERA4HLT=$DATATYPE
-
 if [ ${DATATYPE::3} == "Run" ]; then
-# DATATYPE=${DATATYPE0::7} ## This gives Run2018A -> Run2018
-  case ${ERA::8} in
-    Run2016B|Run2016C|Run2016D|Run2016E)
-      ERA4HLT=Run2016BE
-      ;;
-    Run2016F|Run2016G)
-      ERA4HLT=Run2016FG
-      ;;
-    Run2017C|Run2017D|Run2017E|Run2017F)
-      ERA4HLT=Run2017CF
-      ;;
-  esac
+  HLTMODULE=${ERA::8}_$(echo $DATASET | cut -d/ -f2)
+else
+  HLTMODULE=$(echo $DATATYPE | cut -d_ -f1)
 fi
 
 FILENAMES=$(cat $FILELIST | xargs -n$MAXFILES | sed -n "$(($JOBNUMBER+1)) p" | sed 's;^/xrootd/;root://cms-xrdr.private.lo:2094//xrd/;g')
 
 ARGS=""
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLeptonHLT flags_${DATATYPE}"
-ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLeptonHLT "`echo hlt_{E,M,MM,EE,ME}_${ERA4HLT} | tr ' ' ','`
+ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLeptonHLT hlt_${HLTMODULE}"
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLepton fcnc_${CHANNEL}"
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.fcncTriLeptonCutFlow cutFlow_${CHANNEL}"
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.CopyBranch copyBranch"

--- a/TopAnalysis/test/ttbarDoubleLepton/01_prod_ntuple.sh
+++ b/TopAnalysis/test/ttbarDoubleLepton/01_prod_ntuple.sh
@@ -22,22 +22,13 @@ DATASET='/'`echo $DATASET0 | sed -e 's;\.;/;g'`
 ERA=$(echo $DATASET0 | cut -d. -f2 | cut -d- -f1 | sed -e 's;NanoAOD;;g')
 
 DATATYPE=$(basename $(dirname $FILELIST) | cut -d. -f1)
-ERA4HLT=$DATATYPE
-
-if [ ${DATATYPE::3} == "Run" ]; then
-# DATATYPE=${DATATYPE0::7} ## This gives Run2018A -> Run2018
-  case $ERA in
-    Run2017C|Run2017D|Run2017E|Run2017F)
-      ERA4HLT=Run2017CF
-      ;;
-  esac
-fi
+HLTMODULE=$(echo $DATATYPE | cut -d_ -f1)_${CHANNEL}
 
 FILENAMES=$(cat $FILELIST | xargs -n$MAXFILES | sed -n "$(($JOBNUMBER+1)) p" | sed 's;^/xrootd/;root://cms-xrdr.private.lo:2094//xrd/;g')
 
 ARGS=""
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.ttbarDoubleLeptonHLT flags_${DATATYPE}"
-ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.ttbarDoubleLeptonHLT hlt_${CHANNEL}_${ERA4HLT}"
+ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.ttbarDoubleLeptonHLT hlt_${HLTMODULE}"
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.ttbarDoubleLepton ttbar_${CHANNEL}"
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.ttbarDoubleLeptonCutFlow cutFlow_${CHANNEL}"
 ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.CopyBranch copyBranch"


### PR DESCRIPTION
1. Most complicated HLT logical operations have been done in the .yaml level. No need to store trigger logic bits for the other datasets.

2. Create HLT combine module definitions for each datasets. This super simplifies launcher shell script. This can also isolate HLT combination rule in the .yaml and python configuration file.

3. Fix missing weight formula

4. Do not "double"-correct electron pT.

5. Electron tight ID number should be "4".