### PR TITLE
Code matching with 2016MiniAOD analysis

### DIFF
--- a/NanoAODProduction/data/datasets/NanoAOD/2016/RD.Run2016.yaml
+++ b/NanoAODProduction/data/datasets/NanoAOD/2016/RD.Run2016.yaml
@@ -105,10 +105,10 @@ dataset:
         - /store/data/Run2016H/SingleMuon/NANOAOD/Nano14Dec2018-v1/80000
 luminosity:
     Run2016B_ver1-Nano14Dec2018_ver1-v1: 0
-    Run2016B_ver2-Nano14Dec2018_ver2-v1: 5.814
-    Run2016C-Nano14Dec2018-v1: 2.615
-    Run2016D-Nano14Dec2018-v1: 4.281
-    Run2016E-Nano14Dec2018-v1: 4.035
-    Run2016F-Nano14Dec2018-v1: 3.119
-    Run2016G-Nano14Dec2018-v1: 7.658
-    Run2016H-Nano14Dec2018-v1: 8.773
+    Run2016B_ver2-Nano14Dec2018_ver2-v1: 5.711
+    Run2016C-Nano14Dec2018-v1: 2.573
+    Run2016D-Nano14Dec2018-v1: 4.242
+    Run2016E-Nano14Dec2018-v1: 4.025
+    Run2016F-Nano14Dec2018-v1: 3.105
+    Run2016G-Nano14Dec2018-v1: 7.576
+    Run2016H-Nano14Dec2018-v1: 8.651

--- a/TopAnalysis/data/combineHLT/flags/2016.yaml
+++ b/TopAnalysis/data/combineHLT/flags/2016.yaml
@@ -1,10 +1,10 @@
 RunIISummer16: "Flag_goodVertices
-  && Flag_globalSuperTightHalo2016Filter
+  && Flag_globalTightHalo2016Filter
   && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter
   && Flag_EcalDeadCellTriggerPrimitiveFilter
   && Flag_BadPFMuonFilter && Flag_BadChargedCandidateFilter"
 Run2016: "Flag_goodVertices
-  && Flag_globalSuperTightHalo2016Filter
+  && Flag_globalTightHalo2016Filter
   && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter
   && Flag_EcalDeadCellTriggerPrimitiveFilter
   && Flag_BadPFMuonFilter && Flag_BadChargedCandidateFilter

--- a/TopAnalysis/data/combineHLT/ttbarDoubleLepton/2016.yaml
+++ b/TopAnalysis/data/combineHLT/ttbarDoubleLepton/2016.yaml
@@ -13,10 +13,10 @@ RunIISummer16.DoubleEG: "
 
 RunIISummer16: "
      HLT_IsoMu20 || HLT_IsoTkMu20
-  || HLT_Ele27_WPTight_Gsf
+  || HLT_Ele27_WPTight_Gsf || HLT_Ele32_eta2p1_WPTight_Gsf
   || HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL || HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL
   || HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL || HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL
-  || HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ || HLT_Ele27_WPTight_Gsf
+  || HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ
 "
 
 Run2016BG.DoubleMuon: "
@@ -37,7 +37,6 @@ Run2016BG.MuonEG: "
 "
 Run2016BG.SingleMuon.MuEl: "
      (HLT_IsoMu20 || HLT_IsoTkMu20)
-  && !(HLT_Ele27_WPTight_Gsf)
   && !(HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL || HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL)
 "
 Run2016BG.SingleElectron.MuEl: "
@@ -45,7 +44,6 @@ Run2016BG.SingleElectron.MuEl: "
   && !(HLT_IsoMu20 || HLT_IsoTkMu20)
   && !(HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL || HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL)
 "
-
 Run2016H.DoubleMuon: "
      HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ || HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ
 "
@@ -64,7 +62,6 @@ Run2016H.MuonEG: "
 "
 Run2016H.SingleMuon.MuEl: "
      (HLT_IsoMu20 || HLT_IsoTkMu20)
-  && !(HLT_Ele27_WPTight_Gsf)
   && !(HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ || HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ)
 "
 Run2016H.SingleElectron.MuEl: "

--- a/TopAnalysis/data/combineHLT/ttbarDoubleLepton/2016.yaml
+++ b/TopAnalysis/data/combineHLT/ttbarDoubleLepton/2016.yaml
@@ -13,7 +13,7 @@ RunIISummer16.DoubleEG: "
 
 RunIISummer16: "
      HLT_IsoMu20 || HLT_IsoTkMu20
-  || HLT_Ele27_WPTight_Gsf || HLT_Ele32_eta2p1_WPTight_Gsf
+  || HLT_Ele27_WPTight_Gsf
   || HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL || HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL
   || HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL || HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL
   || HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ

--- a/TopAnalysis/data/histogramming/ttbbDilepton.yaml
+++ b/TopAnalysis/data/histogramming/ttbbDilepton.yaml
@@ -77,7 +77,7 @@ hists:
     Lepton1_eta:
         title: "Lepton1_eta;Leading lepton #eta;Events"
         bins:
-            nbinsX: 100
+            nbinsX: 10
             xmin: -3.0
             xmax:  3.0
     Lepton1_phi:
@@ -96,7 +96,7 @@ hists:
     Lepton2_eta:
         title: "Lepton2_eta;2nd leading lepton #eta;Events"
         bins:
-            nbinsX: 100
+            nbinsX: 10
             xmin: -3.0
             xmax:  3.0
     Lepton2_phi:

--- a/TopAnalysis/data/histogramming/ttbbDilepton.yaml
+++ b/TopAnalysis/data/histogramming/ttbbDilepton.yaml
@@ -77,7 +77,7 @@ hists:
     Lepton1_eta:
         title: "Lepton1_eta;Leading lepton #eta;Events"
         bins:
-            nbinsX: 10
+            nbinsX: 100
             xmin: -3.0
             xmax:  3.0
     Lepton1_phi:
@@ -96,7 +96,7 @@ hists:
     Lepton2_eta:
         title: "Lepton2_eta;2nd leading lepton #eta;Events"
         bins:
-            nbinsX: 10
+            nbinsX: 100
             xmin: -3.0
             xmax:  3.0
     Lepton2_phi:

--- a/TopAnalysis/interface/TTbarDoubleLeptonCppWorker.h
+++ b/TopAnalysis/interface/TTbarDoubleLeptonCppWorker.h
@@ -23,7 +23,7 @@ public:
   void setMuons(TRAF pt, TRAF eta, TRAF phi, TRAF mass, TRAI charge,
                 TRAF relIso, TRAB isTight, TRAB isGlobal, TRAB isPFcand, TRAB isTracker);
   void setElectrons(TRAF pt, TRAF eta, TRAF phi, TRAF mass, TRAI charge,
-                    TRAF relIso, TRAI id, TRAF dEtaSC, TRAF eCorr);
+                    TRAF relIso, TRAI id, TRAF dEtaSC, TRAF eCorr, TRAB isPFcand);
   void setJets(TRAF pt, TRAF eta, TRAF phi, TRAF mass,
                TRAI id, TRAF CSVv2);
   void setMET(TTreeReaderValue<float>* pt, TTreeReaderValue<float>* phi);
@@ -90,6 +90,7 @@ private:
   TRAI in_Electrons_id = nullptr;
   TRAF in_Electrons_dEtaSC = nullptr;
   TRAF in_Electrons_eCorr = nullptr;
+  TRAB in_Electrons_isPFcand = nullptr;
   TRAF in_Jet_p4[4];
   TRAI in_Jet_id = nullptr;
   TRAF in_Jet_CSVv2 = nullptr;

--- a/TopAnalysis/python/postprocessing/ttbarDoubleLepton.py
+++ b/TopAnalysis/python/postprocessing/ttbarDoubleLepton.py
@@ -55,7 +55,7 @@ class TTbarDoubleLepton(Module, object):
         objName = "Electron"
         setattr(self, "b_n%s" % objName, tree.valueReader("n%s" % objName))
         for varName in ["pt", "eta", "phi", "mass", "charge",
-                        "pfRelIso03_all", self.eleIdName, "deltaEtaSC", "eCorr"]:
+                        "pfRelIso03_all", self.eleIdName, "deltaEtaSC", "eCorr", "isPFcand"]:
             setattr(self, "b_%s_%s" % (objName, varName), tree.arrayReader("%s_%s" % (objName, varName)))
 
         objName = "Muon"
@@ -73,7 +73,7 @@ class TTbarDoubleLepton(Module, object):
         self.worker.setMET(self.b_MET_pt, self.b_MET_phi)
         self.worker.setElectrons(self.b_Electron_pt, self.b_Electron_eta, self.b_Electron_phi, self.b_Electron_mass, self.b_Electron_charge,
                                  self.b_Electron_pfRelIso03_all, getattr(self, "b_Electron_%s" % self.eleIdName),
-                                 self.b_Electron_deltaEtaSC, self.b_Electron_eCorr)
+                                 self.b_Electron_deltaEtaSC, self.b_Electron_eCorr, self.b_Electron_isPFcand)
         self.worker.setMuons(self.b_Muon_pt, self.b_Muon_eta, self.b_Muon_phi, self.b_Muon_mass, self.b_Muon_charge,
                              self.b_Muon_pfRelIso04_all,self.b_Muon_tightId, self.b_Muon_isGlobal, self.b_Muon_isPFcand, self.b_Muon_isTracker)
         self.worker.setJets(self.b_Jet_pt, self.b_Jet_eta, self.b_Jet_phi, self.b_Jet_mass,

--- a/TopAnalysis/python/postprocessing/ttbarDoubleLeptonCutFlow.py
+++ b/TopAnalysis/python/postprocessing/ttbarDoubleLeptonCutFlow.py
@@ -28,7 +28,7 @@ class TTbarDoubleLeptonCutFlow(Module, object):
             if event._tree.b_out_Z_charge != 0 or event._tree.b_out_Z_mass < 20 or\
                event._tree.b_out_Lepton1_pt < 25 or event._tree.b_out_Lepton2_pt < 20: break
             cutStep += 1
-            if self.doZVetoCut and ((75 < event._tree.b_out_Z_mass) and (event._tree.b_out_Z_mass < 105)): break
+            if self.doZVetoCut and ((76 < event._tree.b_out_Z_mass) and (event._tree.b_out_Z_mass < 106)): break
             cutStep += 1
             if self.doMETCut and event._tree.b_out_MET_pt < 40: break
             cutStep += 1

--- a/TopAnalysis/src/TTbarDoubleLeptonCppWorker.cc
+++ b/TopAnalysis/src/TTbarDoubleLeptonCppWorker.cc
@@ -21,7 +21,7 @@ typedef TTbarDoubleLeptonCppWorker::TRAI TRAI;
 typedef TTbarDoubleLeptonCppWorker::TRAB TRAB;
 
 void TTbarDoubleLeptonCppWorker::setElectrons(TRAF pt, TRAF eta, TRAF phi, TRAF mass, TRAI charge,
-                                              TRAF relIso, TRAI id, TRAF dEtaSC, TRAF eCorr) {
+                                              TRAF relIso, TRAI id, TRAF dEtaSC, TRAF eCorr, TRAB isPFcand) {
   in_Electrons_p4[0] = pt;
   in_Electrons_p4[1] = eta;
   in_Electrons_p4[2] = phi;
@@ -31,6 +31,7 @@ void TTbarDoubleLeptonCppWorker::setElectrons(TRAF pt, TRAF eta, TRAF phi, TRAF 
   in_Electrons_id = id;
   in_Electrons_dEtaSC = dEtaSC;
   in_Electrons_eCorr = eCorr;
+  in_Electrons_isPFcand = isPFcand;
 }
 
 void TTbarDoubleLeptonCppWorker::setMuons(TRAF pt, TRAF eta, TRAF phi, TRAF mass, TRAI charge,
@@ -79,8 +80,8 @@ bool TTbarDoubleLeptonCppWorker::isGoodMuon(const unsigned i) const {
   const double pt = in_Muons_p4[0]->At(i);
   const double eta = in_Muons_p4[1]->At(i);
   if ( pt < minLepton2Pt_ or std::abs(eta) > maxLepton2Eta_ ) return false;
-  //if ( in_Muons_isTight->At(i) == 0 ) return false;
-  if ( ! (in_Muons_isPFcand->At(i) != 0 and (in_Muons_isGlobal->At(i) != 0 or in_Muons_isTracker->At(i) != 0)) ) return false;
+  if ( in_Muons_isTight->At(i) == 0 ) return false;
+  //if ( ! (in_Muons_isPFcand->At(i) != 0 and (in_Muons_isGlobal->At(i) != 0 or in_Muons_isTracker->At(i) != 0)) ) return false;
   if ( in_Muons_relIso->At(i) > maxMuonRelIso_ ) return false;
 
   return true;
@@ -89,8 +90,10 @@ bool TTbarDoubleLeptonCppWorker::isGoodMuon(const unsigned i) const {
 bool TTbarDoubleLeptonCppWorker::isGoodElectron(const unsigned i) const {
   const double pt = in_Electrons_p4[0]->At(i);
   const double eta = in_Electrons_p4[1]->At(i);
+  const double SCeta = eta + in_Electrons_dEtaSC->At(i);
   if ( pt < minLepton2Pt_ or std::abs(eta) > maxLepton2Eta_ ) return false;
-  if ( in_Electrons_id->At(i) <= 3 ) return false;
+  if ( std::abs(SCeta) > 1.442 and std::abs(SCeta) < 1.566 ) return false;
+  if ( in_Electrons_isPFcand->At(i) == 0 or in_Electrons_id->At(i) != 4 ) return false;
   //if ( in_Electrons_relIso->At(i) < 0.15 ) return false; // Note: commented out since already applied in Cut based ID
 
   return true;


### PR DESCRIPTION
Code matching with 2016 MiniAOD analysis

1. Recalculated datalumi
2. Event filter(GlobalTightHalo2016)
3. Trigger path at SingleMuon dataset, MuEl channel
4. Muon Id (Tight)
5. Electron PFcand, SCeta veto (1.4442 < |SCeta| < 1.566)
6. Z mass veto is changed.