### PR TITLE
Supplement the NPL logic about missing events from each channel

### DIFF
--- a/TopAnalysis/interface/FCNCTriLeptonCppWorker.h
+++ b/TopAnalysis/interface/FCNCTriLeptonCppWorker.h
@@ -80,7 +80,9 @@ public:
 
   float get_W_MT() const { return out_W_MT; }
 
-  unsigned get_nVetoLepton() const { return out_nVetoLepton; }
+  unsigned get_nVetoElectron() const { return out_nVetoElectron; }
+  unsigned get_nVetoMuon() const { return out_nVetoMuon; }
+  unsigned get_nVetoLepton() const { return out_nVetoElectron + out_nVetoMuon; }
   unsigned get_nGoodElectron() const { return out_nGoodElectron; }
   unsigned get_nGoodMuon() const { return out_nGoodMuon; }
   unsigned get_nGoodLepton() const { return out_nGoodElectron + out_nGoodMuon; }
@@ -163,9 +165,11 @@ private:
 
   short out_GoodLeptonCode;
   unsigned short out_GoodLepton;
-  unsigned short out_nVetoLepton;
   unsigned short out_nGoodElectron;
   unsigned short out_nGoodMuon;
+  unsigned short out_nVetoLepton;
+  unsigned short out_nVetoElectron;
+  unsigned short out_nVetoMuon;
   unsigned short out_nGoodJet, out_nBjet;
   std::vector<float> out_GoodJet_p4[4];
   std::vector<float> out_GoodJet_CSVv2;

--- a/TopAnalysis/python/postprocessing/fcncKinematicReco.py
+++ b/TopAnalysis/python/postprocessing/fcncKinematicReco.py
@@ -3,6 +3,7 @@ import math
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
 import os
+from ROOT import TLorentzVector
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 

--- a/TopAnalysis/python/postprocessing/fcncKinematicReco.py
+++ b/TopAnalysis/python/postprocessing/fcncKinematicReco.py
@@ -156,9 +156,9 @@ class FCNCKinematicReco(Module, object):
 
             posTMass = self.getTPEPM(SMpxs, SMpys, posSMpzs, posSMEs)[3]
             negTMass = self.getTPEPM(SMpxs, SMpys, negSMpzs, negSMEs)[3]
-        
+
             ## Top mass variance comparison and reconsruct SM Top KinVals
-           if ( math.fabs(posTMass - OriginTmass) < math.fabs(negTMass - OriginTmass) ):
+            if ( math.fabs(posTMass - OriginTmass) < math.fabs(negTMass - OriginTmass) ):
                 SMTMass = posTMass
                 SMTKinVal = self.getTPEPM(SMpxs, SMpys, posSMpzs, posSMEs)
             else:

--- a/TopAnalysis/python/postprocessing/fcncTriLeptonCutFlow.py
+++ b/TopAnalysis/python/postprocessing/fcncTriLeptonCutFlow.py
@@ -27,7 +27,10 @@ class FCNCTriLeptonCutFlow(Module, object):
             if abs(event._tree.b_out_GoodLeptonCode) != 111: break
             cutStep += 1
             #if event._tree.b_out_GoodLeptonCode < 0: break
-            if event._tree.b_out_nGoodLepton != 3: break
+            if 'NPL' in mode:
+              if (event._tree.b_out_nGoodLepton != 2 and event._tree.b_out_nVetoLepton > 0): break
+            else:
+              if event._tree.b_out_nGoodLepton != 3: break
             cutStep += 1
             #if event._tree.b_out_nVetoLepton > 0: break
             if not (82.5 <= event._tree.b_out_Z_mass <= 97.5): break

--- a/TopAnalysis/python/postprocessing/fcncTriLeptonCutFlow.py
+++ b/TopAnalysis/python/postprocessing/fcncTriLeptonCutFlow.py
@@ -27,7 +27,7 @@ class FCNCTriLeptonCutFlow(Module, object):
             if abs(event._tree.b_out_GoodLeptonCode) != 111: break
             cutStep += 1
             #if event._tree.b_out_GoodLeptonCode < 0: break
-            if 'NPL' in mode:
+            if 'NPL' in self.mode:
               if (event._tree.b_out_nGoodLepton != 2 and event._tree.b_out_nVetoLepton > 0): break
             else:
               if event._tree.b_out_nGoodLepton != 3: break

--- a/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
+++ b/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
@@ -79,8 +79,9 @@ void FCNCTriLeptonCppWorker::resetValues() {
   out_Z_charge = 0;
   out_MET_pt = out_MET_phi = 0;
   out_W_MT = 0;
-  out_GoodLeptonCode = out_nVetoLepton = 0;
+  out_GoodLeptonCode = 0;
   out_nGoodElectron = out_nGoodMuon = 0;
+  out_nVetoElectron = out_nVetoMuon = 0;
   out_nGoodJet = out_nBjet = 0;
   for ( int i=0; i<4; ++i ) out_GoodJet_p4[i].clear();
   out_GoodJet_CSVv2.clear();
@@ -255,6 +256,9 @@ bool FCNCTriLeptonCppWorker::analyze() {
   nVetoElectrons -= nGoodElectrons;
   out_nGoodMuon = nGoodMuons;
   out_nGoodElectron = nGoodElectrons;
+  out_nVetoMuon = nVetoMuons;
+  out_nVetoElectron = nVetoElectrons;
+  
   //out_nVetoLepton = nVetoMuons + nVetoElectrons;
   TLorentzVector lepton1P4, lepton2P4, lepton3P4;
 
@@ -413,11 +417,12 @@ bool FCNCTriLeptonCppWorker::analyze() {
         else ++nVetoMuons;
       }
     }
+    out_nVetoMuon = nVetoMuons;
+    out_nVetoElectron = nVetoElectrons;
   }
 
   // Done for the leptons
 
-  out_nVetoLepton = nVetoMuons + nVetoElectrons;
   out_GoodLeptonCode = 0; // GoodLepton "code". 
   //leading lepton> 25GeV, 2nd,3rd lepton> 20GeV (in GoodMu, Ele object: just >20GeV cut applied)
   // 111: all matched with the desired channel/mode

--- a/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
+++ b/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
@@ -323,23 +323,82 @@ bool FCNCTriLeptonCppWorker::analyze() {
     }
   }
 
-  // For the NPL selection: use one lepton with inverted isolation for the 3rd lepton
+  // For the NPL selection: use one lepton with inverted isolation + additional cut (It is included in NPMuon, NPElectron)
   if ( doNonPromptLepton_ ) {
-    // Treat 3rd lepton as veto lepton, which is isolated
-    if ( std::abs(out_Lepton3_pdgId) == 13 ) ++nVetoMuons;
-    else if ( std::abs(out_Lepton3_pdgId) == 11 ) ++nVetoElectrons;
-
-    if ( npMuonIdx >= 0 and std::abs(out_Lepton3_pdgId) != 11 ) {
-      lepton3P4 = buildP4(in_Muons_p4, npMuonIdx);
-      out_Lepton3_pdgId = -13*in_Muons_charge->At(npMuonIdx);
-    }
-    else if ( npElectronIdx >= 0 and std::abs(out_Lepton3_pdgId) != 13 ) {
-      lepton3P4 = buildP4(in_Electrons_p4, npElectronIdx);
-      out_Lepton3_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
-    }
-    else {
-      lepton3P4 = TLorentzVector();
-      out_Lepton3_pdgId = 0;
+    //
+    // Selection in NPL nutple: 
+    // 1. Each event has only TWO PL -> When the event has 3 PL, then that event should be vetoed.
+    // 2. We do not care about number of NPL in each event.
+    // But one NPL which has highest pt in the one of NPLs from each event should be contained in the Lepton 1,2 or 3.
+    //
+    // NPL Selection 1.
+    if ( ( nGoodMuons + nGoodElectrons ) == 2 ) {
+      //NPL selection 2. in NP electron
+      if ( npElectronIdx >= 0 and ( npElectronPt > npMuonPt ) ) {
+        if ( actualMode == MODE::ElElEl ) {
+          if ( std::abs(out_Lepton1_pdgId) == 0 ) {
+            lepton1P4 = buildP4(in_Electrons_p4, npElectronIdx);
+            out_Lepton1_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
+          }
+          if ( std::abs(out_Lepton2_pdgId) == 0 ) {
+            lepton2P4 = buildP4(in_Electrons_p4, npElectronIdx);
+            out_Lepton2_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
+          }
+          if ( std::abs(out_Lepton3_pdgId) == 0 ) {
+            lepton3P4 = buildP4(in_Electrons_p4, npElectronIdx);
+            out_Lepton3_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
+          }
+        }
+        if ( actualMode == MODE::MuElEl ) {
+          if ( std::abs(out_Lepton2_pdgId) == 0 ) {
+            lepton2P4 = buildP4(in_Electrons_p4, npElectronIdx);
+            out_Lepton2_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
+          }
+          if ( std::abs(out_Lepton3_pdgId) == 0 ) {
+            lepton3P4 = buildP4(in_Electrons_p4, npElectronIdx);
+            out_Lepton3_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
+          }
+        }
+        if ( actualMode == MODE::ElMuMu ) {
+          if ( std::abs(out_Lepton1_pdgId) == 0 ) {
+            lepton1P4 = buildP4(in_Electrons_p4, npElectronIdx);
+            out_Lepton1_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
+          }
+        }
+      }
+      //NPL selection 2. in NP muon
+      if ( npMuonIdx >= 0 and ( npMuonPt > npElectronPt ) ) { 
+        if ( actualMode == MODE::MuMuMu ) {
+          if ( std::abs(out_Lepton1_pdgId) == 0 ) {
+            lepton1P4 = buildP4(in_Muons_p4, npMuonIdx);
+            out_Lepton1_pdgId = -11*in_Muons_charge->At(npMuonIdx);
+          }
+          if ( std::abs(out_Lepton2_pdgId) == 0 ) {
+            lepton2P4 = buildP4(in_Muons_p4, npMuonIdx);
+            out_Lepton2_pdgId = -11*in_Muons_charge->At(npMuonIdx);
+          }
+          if ( std::abs(out_Lepton3_pdgId) == 0 ) {
+            lepton3P4 = buildP4(in_Muons_p4, npMuonIdx);
+            out_Lepton3_pdgId = -11*in_Muons_charge->At(npMuonIdx);
+          }
+        }
+        if ( actualMode == MODE::ElMuMu ) {
+          if ( std::abs(out_Lepton2_pdgId) == 0 ) {
+            lepton2P4 = buildP4(in_Muons_p4, npMuonIdx);
+            out_Lepton2_pdgId = -11*in_Muons_charge->At(npMuonIdx);
+          }
+          if ( std::abs(out_Lepton3_pdgId) == 0 ) {
+            lepton3P4 = buildP4(in_Muons_p4, npMuonIdx);
+            out_Lepton3_pdgId = -11*in_Muons_charge->At(npMuonIdx);
+          }
+        }
+        if ( actualMode == MODE::MuElEl ) {
+          if ( std::abs(out_Lepton1_pdgId) == 0 ) {
+            lepton1P4 = buildP4(in_Muons_p4, npMuonIdx);
+            out_Lepton1_pdgId = -11*in_Muons_charge->At(npMuonIdx);
+          }
+        }
+      }
     }
   }
 
@@ -351,6 +410,7 @@ bool FCNCTriLeptonCppWorker::analyze() {
   // -111: all matched with the desired channel/mode but wrong sign
   // 110: missing one lepton  
   // 101: missing one lepton
+  // 011: missing one lepton
   // 100: missing two same flavour leptons for muee/emumu
   // 001: missing two of three leptons for eee/mumumu, two different flav leptons for muee/emumu
   // 000: no leptons found in this event

--- a/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
+++ b/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
@@ -255,7 +255,7 @@ bool FCNCTriLeptonCppWorker::analyze() {
   nVetoElectrons -= nGoodElectrons;
   out_nGoodMuon = nGoodMuons;
   out_nGoodElectron = nGoodElectrons;
-  out_nVetoLepton = nVetoMuons + nVetoElectrons;
+  //out_nVetoLepton = nVetoMuons + nVetoElectrons;
   TLorentzVector lepton1P4, lepton2P4, lepton3P4;
 
   // Select event by decay mode
@@ -336,74 +336,88 @@ bool FCNCTriLeptonCppWorker::analyze() {
       //NPL selection 2. in NP electron
       if ( npElectronIdx >= 0 and ( npElectronPt > npMuonPt ) ) {
         if ( actualMode == MODE::ElElEl ) {
-          if ( std::abs(out_Lepton1_pdgId) == 0 ) {
+          if ( std::abs(out_Lepton1_pdgId) == 0 and std::abs(out_Lepton2_pdgId) != 0 and std::abs(out_Lepton3_pdgId) != 0 ) {
             lepton1P4 = buildP4(in_Electrons_p4, npElectronIdx);
             out_Lepton1_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
           }
-          if ( std::abs(out_Lepton2_pdgId) == 0 ) {
+          else if ( std::abs(out_Lepton2_pdgId) == 0 and std::abs(out_Lepton1_pdgId) != 0 and std::abs(out_Lepton3_pdgId) != 0 ) {
             lepton2P4 = buildP4(in_Electrons_p4, npElectronIdx);
             out_Lepton2_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
           }
-          if ( std::abs(out_Lepton3_pdgId) == 0 ) {
+          else if ( std::abs(out_Lepton3_pdgId) == 0 and std::abs(out_Lepton1_pdgId) != 0 and std::abs(out_Lepton2_pdgId) != 0 ) {
             lepton3P4 = buildP4(in_Electrons_p4, npElectronIdx);
             out_Lepton3_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
           }
         }
-        if ( actualMode == MODE::MuElEl ) {
-          if ( std::abs(out_Lepton2_pdgId) == 0 ) {
+        else if ( actualMode == MODE::MuElEl ) {
+          if ( std::abs(out_Lepton2_pdgId) == 0 and std::abs(out_Lepton1_pdgId) != 0 and std::abs(out_Lepton3_pdgId) != 0 ) {
             lepton2P4 = buildP4(in_Electrons_p4, npElectronIdx);
             out_Lepton2_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
           }
-          if ( std::abs(out_Lepton3_pdgId) == 0 ) {
+          else if ( std::abs(out_Lepton3_pdgId) == 0 and std::abs(out_Lepton1_pdgId) != 0 and std::abs(out_Lepton2_pdgId) != 0 ) {
             lepton3P4 = buildP4(in_Electrons_p4, npElectronIdx);
             out_Lepton3_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
           }
         }
-        if ( actualMode == MODE::ElMuMu ) {
-          if ( std::abs(out_Lepton1_pdgId) == 0 ) {
+        else if ( actualMode == MODE::ElMuMu ) {
+          if ( std::abs(out_Lepton1_pdgId) == 0 and std::abs(out_Lepton2_pdgId) != 0 and std::abs(out_Lepton3_pdgId) != 0 ) {
             lepton1P4 = buildP4(in_Electrons_p4, npElectronIdx);
             out_Lepton1_pdgId = -11*in_Electrons_charge->At(npElectronIdx);
           }
         }
       }
       //NPL selection 2. in NP muon
-      if ( npMuonIdx >= 0 and ( npMuonPt > npElectronPt ) ) { 
+      else if ( npMuonIdx >= 0 and ( npMuonPt > npElectronPt ) ) { 
         if ( actualMode == MODE::MuMuMu ) {
-          if ( std::abs(out_Lepton1_pdgId) == 0 ) {
+          if ( std::abs(out_Lepton1_pdgId) == 0 and std::abs(out_Lepton2_pdgId) != 0 and std::abs(out_Lepton3_pdgId) != 0 ) {
             lepton1P4 = buildP4(in_Muons_p4, npMuonIdx);
             out_Lepton1_pdgId = -11*in_Muons_charge->At(npMuonIdx);
           }
-          if ( std::abs(out_Lepton2_pdgId) == 0 ) {
+          else if ( std::abs(out_Lepton2_pdgId) == 0 and std::abs(out_Lepton1_pdgId) != 0 and std::abs(out_Lepton3_pdgId) != 0 ) {
             lepton2P4 = buildP4(in_Muons_p4, npMuonIdx);
             out_Lepton2_pdgId = -11*in_Muons_charge->At(npMuonIdx);
           }
-          if ( std::abs(out_Lepton3_pdgId) == 0 ) {
+          else if ( std::abs(out_Lepton3_pdgId) == 0 and std::abs(out_Lepton1_pdgId) != 0 and std::abs(out_Lepton2_pdgId) != 0 ) {
             lepton3P4 = buildP4(in_Muons_p4, npMuonIdx);
             out_Lepton3_pdgId = -11*in_Muons_charge->At(npMuonIdx);
           }
         }
-        if ( actualMode == MODE::ElMuMu ) {
-          if ( std::abs(out_Lepton2_pdgId) == 0 ) {
+        else if ( actualMode == MODE::ElMuMu ) {
+          if ( std::abs(out_Lepton2_pdgId) == 0 and std::abs(out_Lepton1_pdgId) != 0 and std::abs(out_Lepton3_pdgId) != 0 ) {
             lepton2P4 = buildP4(in_Muons_p4, npMuonIdx);
             out_Lepton2_pdgId = -11*in_Muons_charge->At(npMuonIdx);
           }
-          if ( std::abs(out_Lepton3_pdgId) == 0 ) {
+          else if ( std::abs(out_Lepton3_pdgId) == 0 and std::abs(out_Lepton1_pdgId) != 0 and std::abs(out_Lepton2_pdgId) != 0 ) {
             lepton3P4 = buildP4(in_Muons_p4, npMuonIdx);
             out_Lepton3_pdgId = -11*in_Muons_charge->At(npMuonIdx);
           }
         }
-        if ( actualMode == MODE::MuElEl ) {
-          if ( std::abs(out_Lepton1_pdgId) == 0 ) {
+        else if ( actualMode == MODE::MuElEl ) {
+          if ( std::abs(out_Lepton1_pdgId) == 0 and std::abs(out_Lepton2_pdgId) != 0 and std::abs(out_Lepton3_pdgId) != 0 ) {
             lepton1P4 = buildP4(in_Muons_p4, npMuonIdx);
             out_Lepton1_pdgId = -11*in_Muons_charge->At(npMuonIdx);
           }
         }
       }
     }
+    // Treat nGoodMuon + nGoodElectron == 3 case because the event already has three PL.
+    else {
+      if ( nGoodMuons == 3 ) ++nVetoMuons;
+      else if ( nGoodElectrons == 3 ) ++nVetoElectrons;
+      else if ( nGoodElectrons == 1 and nGoodMuons == 2 and actualMode == MODE::ElMuMu ) { 
+        if ( lepton1P4.Pt() > lepton3P4.Pt() ) ++nVetoMuons;
+        else ++nVetoElectrons;
+      }
+      else if ( nGoodMuons == 1 and nGoodElectrons == 2 and actualMode == MODE::MuElEl ) {
+        if ( lepton1P4.Pt() > lepton3P4.Pt() ) ++nVetoElectrons;
+        else ++nVetoMuons;
+      }
+    }
   }
 
   // Done for the leptons
 
+  out_nVetoLepton = nVetoMuons + nVetoElectrons;
   out_GoodLeptonCode = 0; // GoodLepton "code". 
   //leading lepton> 25GeV, 2nd,3rd lepton> 20GeV (in GoodMu, Ele object: just >20GeV cut applied)
   // 111: all matched with the desired channel/mode


### PR DESCRIPTION
This PR is described about supplement the NPL logic.

Before this PR, NPL was contained only in the 'Lepton3_p4' regardless of channel.
This would be omitted some NPL.
ex)
PL filled at Lepton2_p4, Lepton3_p4 (el,el) & event has NP Muon (npMuonIdx >=0)
-> In NPL loop (doNonPromptLepton),
NP Muon cannot be filled in the Lepton3 because electron is already filled in the Lepton3_p4 (std::abs(out_Lepton3_pdgId) == 11)

So I supplement the NPL logic for missing events like ex).