### PR TITLE
Changing b discriminator: CSVv2 to DeepFlav (deepjet)

### DIFF
--- a/NanoAODProduction/data/crosssection/13TeV.yaml
+++ b/NanoAODProduction/data/crosssection/13TeV.yaml
@@ -1,5 +1,5 @@
 crosssection:
-  DYJetsToLL_M-50    : 6225.42
+  DYJetsToLL_M-50    : 6077.22
   DYJetsToLL_M-10to50: 18610
 
   WJets : 61526.7

--- a/NanoAODProduction/data/datasets/NanoAOD/2016/MC.RunIISummer16.central.yaml
+++ b/NanoAODProduction/data/datasets/NanoAOD/2016/MC.RunIISummer16.central.yaml
@@ -66,8 +66,8 @@ dataset:
             - /store/mc/RunIISummer16NanoAODv6/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/260000
         ? /WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext2-v1/NANOAODSIM
         :   - /store/mc/RunIISummer16NanoAODv6/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext2-v1/260000
-            - /store/mc/RunIISummer16NanoAODv6/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext2-v1/70000
             - /store/mc/RunIISummer16NanoAODv6/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext2-v1/270000
+            - /store/mc/RunIISummer16NanoAODv6/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext2-v1/70000
     MC2016.WW:
         /WW_TuneCUETP8M1_13TeV-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM:
         - /store/mc/RunIISummer16NanoAODv6/WW_TuneCUETP8M1_13TeV-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/280000

--- a/NanoAODProduction/data/datasets/NanoAOD/2016/MC.RunIISummer16.rareprocess.yaml
+++ b/NanoAODProduction/data/datasets/NanoAOD/2016/MC.RunIISummer16.rareprocess.yaml
@@ -24,8 +24,9 @@ dataset:
         ? /TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM
         :   - /store/mc/RunIISummer16NanoAODv6/TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/270000
     MC2016.TT_FCNC-T2ZJ_zct:
-        ? /TT_FCNC-T2ZJ_aTleptonic_ZToll_kappa_zct-MadGraph5-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM
-        : []
+        ? /TT_FCNC-T2ZJ_aTleptonic_ZToll_kappa_zct-MadGraph5-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/NANOAODSIM
+        :   - /store/mc/RunIISummer16NanoAODv6/TT_FCNC-T2ZJ_aTleptonic_ZToll_kappa_zct-MadGraph5-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/40000
+            - /store/mc/RunIISummer16NanoAODv6/TT_FCNC-T2ZJ_aTleptonic_ZToll_kappa_zct-MadGraph5-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7_ext1-v1/250000
     MC2016.TT_FCNC-T2ZJ_zut:
         ? /TT_FCNC-T2ZJ_aTleptonic_ZToll_kappa_zut-MadGraph5-pythia8/RunIISummer16NanoAODv6-PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/NANOAODSIM
         :   - /store/mc/RunIISummer16NanoAODv6/TT_FCNC-T2ZJ_aTleptonic_ZToll_kappa_zut-MadGraph5-pythia8/NANOAODSIM/PUMoriond17_Nano25Oct2019_102X_mcRun2_asymptotic_v7-v1/260000

--- a/TopAnalysis/data/histogramming/fcncTrilepton.yaml
+++ b/TopAnalysis/data/histogramming/fcncTrilepton.yaml
@@ -59,7 +59,7 @@ steps:
               "Lepton1_pt", "Lepton2_pt", "Lepton3_pt",
               "Lepton1_eta", "TriLepton_mass", "TriLepton_pt", "TriLepton_WleptonZdPhi", "TriLepton_WleptonZdR", 
               "Z_pt", "Z_mass", "W_MT",
-              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_CSVv2",
+              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_DeepFlavB",
               "MET_pt", "MET_phi",]
 
     - name: "STCR"
@@ -68,7 +68,7 @@ steps:
               "Lepton1_pt", "Lepton2_pt", "Lepton3_pt",
               "Lepton1_eta", "TriLepton_mass", "TriLepton_pt", "TriLepton_WleptonZdPhi", "TriLepton_WleptonZdR",
               "Z_pt", "Z_mass", "W_MT",
-              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_CSVv2",
+              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_DeepFlavB",
               "MET_pt", "MET_phi",]
 
     - name: "STSR"
@@ -77,7 +77,7 @@ steps:
               "Lepton1_pt", "Lepton2_pt", "Lepton3_pt",
               "Lepton1_eta", "TriLepton_mass", "TriLepton_pt", "TriLepton_WleptonZdPhi", "TriLepton_WleptonZdR",
               "Z_pt", "Z_mass", "W_MT",
-              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_CSVv2",
+              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_DeepFlavB",
               "MET_pt", "MET_phi",]
 
     - name: "TTCR_allZ"
@@ -86,7 +86,7 @@ steps:
               "Lepton1_pt", "Lepton2_pt", "Lepton3_pt",
               "Lepton1_eta", "TriLepton_mass", "TriLepton_pt", "TriLepton_WleptonZdPhi", "TriLepton_WleptonZdR",
               "Z_pt", "Z_mass", "W_MT",
-              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_CSVv2",
+              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_DeepFlavB",
               "MET_pt", "MET_phi",]
 
     - name: "TTCR"
@@ -95,7 +95,7 @@ steps:
               "Lepton1_pt", "Lepton2_pt", "Lepton3_pt",
               "Lepton1_eta", "TriLepton_mass", "TriLepton_pt", "TriLepton_WleptonZdPhi", "TriLepton_WleptonZdR",
               "Z_pt", "Z_mass", "W_MT",
-              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_CSVv2",
+              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_DeepFlavB",
               "MET_pt", "MET_phi",]
 
     - name: "TTSR"
@@ -104,7 +104,7 @@ steps:
               "Lepton1_pt", "Lepton2_pt", "Lepton3_pt",
               "Lepton1_eta", "TriLepton_mass", "TriLepton_pt", "TriLepton_WleptonZdPhi", "TriLepton_WleptonZdR",
               "Z_pt", "Z_mass", "W_MT",
-              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_CSVv2",
+              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_DeepFlavB",
               "MET_pt", "MET_phi",]
 
     - name: "WZCR_0b"
@@ -113,7 +113,7 @@ steps:
               "Lepton1_pt", "Lepton2_pt", "Lepton3_pt", "Lepton1_eta", "Lepton2_eta", "Lepton3_eta",
               "TriLepton_mass", "TriLepton_pt", "TriLepton_WleptonZdPhi", "TriLepton_WleptonZdR",
               "Z_pt", "Z_mass", "W_MT",
-              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_CSVv2",
+              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_DeepFlavB",
               "MET_pt", "MET_phi",]
 
     - name: "WZCR_23jet"
@@ -122,8 +122,24 @@ steps:
               "Lepton1_pt", "Lepton2_pt", "Lepton3_pt", "Lepton1_eta", "Lepton2_eta", "Lepton3_eta", 
               "TriLepton_mass", "TriLepton_pt", "TriLepton_WleptonZdPhi", "TriLepton_WleptonZdR",
               "Z_pt", "Z_mass", "W_MT",
-              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_CSVv2",
+              "nGoodJet", "nBjet", "nGoodJet_nBjet", "GoodJet_DeepFlavB",
               "MET_pt", "MET_phi",]
+
+    - name: "more1jet_0bjet"
+      cuts: ["CutStep >= 2", "LeadingLepton_pt>25", "nGoodJet>=1", "nBjet==0"] #exactly 3 lepton
+      hists: ["Z_pt", "Z_mass","nGoodJet_nBjet",]
+
+    - name: "more1jet_more1bjet"
+      cuts: ["CutStep >= 2", "LeadingLepton_pt>25", "nGoodJet>=1", "nBjet>=1"] #exactly 3 lepton
+      hists: ["Z_pt", "Z_mass","nGoodJet_nBjet",]
+
+    - name: "23jet_0bjet"
+      cuts: ["CutStep >= 2", "LeadingLepton_pt>25", "nGoodJet>=2", "nGoodJet<=3", "nBjet==0"] #exactly 3 lepton
+      hists: ["Z_pt", "Z_mass","nGoodJet_nBjet",]
+
+    - name: "23jet_more1bjet"
+      cuts: ["CutStep >= 2", "LeadingLepton_pt>25", "nGoodJet>=2", "nGoodJet<=3", "nBjet>=1"] #exactly 3 lepton
+      hists: ["Z_pt", "Z_mass","nGoodJet_nBjet",]
 
 hists:
     nPV_noWeight:
@@ -262,12 +278,12 @@ hists:
             nbinsY: 10
             ymin: 0
             ymax: 10
-    GoodJet_CSVv2:
-        title: "GoodJet_CSVv2;FCNC jet CSVv2"
+    GoodJet_DeepFlavB:
+        title: "GoodJet_DeepFlavB;FCNC jet DeepFlavB"
         bins:
             nbinsX: 15
             xmin: 0
-            xmax: 0.6
+            xmax: 0.1
     W_MT:
         title: "W_MT;Transeverse mass of W boson;Events"
         bins:

--- a/TopAnalysis/data/plots/fcncTrilepton.yaml
+++ b/TopAnalysis/data/plots/fcncTrilepton.yaml
@@ -1,4 +1,4 @@
-lumi: [5.711,2.573,4.242,4.025,3.105,7.576,8.651] #2016
+lumi: [5.746,2.573,4.242,4.025,3.105,7.576,8.651] #2016
 #lumi: [4.77, 9.58, 4.22, 9.26, 13.46] #2017
 
 canvasStyles: ## Styling rules, later item overrides earlier ones

--- a/TopAnalysis/interface/FCNCTriLeptonCppWorker.h
+++ b/TopAnalysis/interface/FCNCTriLeptonCppWorker.h
@@ -27,7 +27,7 @@ public:
   void setElectrons(TRAF pt, TRAF eta, TRAF phi, TRAF mass, TRAI charge,
                     TRAF relIso, TRAI id, TRAF dEtaSC, TRAF eCorr, TRAI vidBitmap);
   void setJets(TRAF pt, TRAF eta, TRAF phi, TRAF mass,
-               TRAI id, TRAF CSVv2);
+               TRAI id, TRAF DeepFlavB);
   void setMET(TTreeReaderValue<float>* pt, TTreeReaderValue<float>* phi);
 
   void resetValues();
@@ -93,7 +93,7 @@ public:
   std::vector<float> get_GoodJet_eta()  const { return out_GoodJet_p4[1]; }
   std::vector<float> get_GoodJet_phi()  const { return out_GoodJet_p4[2]; }
   std::vector<float> get_GoodJet_mass() const { return out_GoodJet_p4[3]; }
-  std::vector<float> get_GoodJet_CSVv2() const { return out_GoodJet_CSVv2; }
+  std::vector<float> get_GoodJet_DeepFlavB() const { return out_GoodJet_DeepFlavB; }
   std::vector<unsigned short> get_GoodJet_index() const { return out_GoodJet_index; }
   unsigned get_nBjet() const { return out_nBjet; }
 
@@ -101,8 +101,9 @@ private:
   const double minMuonPt_ = 20, maxMuonEta_ = 2.4; //Signal & veto reco. cuts are same
   const double minElectronPt_ = 20, maxElectronEta_ = 2.4; //Signal & veto reco. cuts are same
   const double minJetPt_ = 30, maxJetEta_ = 2.4;
-  const double minBjetBDiscr_ = 0.5426; // FIXME: give updated number (here, use Loose Working Point)
-  //const double minBjetBDiscr_ = 0.5803; // FIXME: 2017, Loose Working Point (Midium: 0.8838, Tight: 0.9693)
+  //const double minBjetBDiscr_ = 0.5426; // FIXME: give updated number (2016 CSVv2, use Loose Working Point)
+  const double minBjetBDiscr_ = 0.0614; // FIXME: 2016 DeepFlavB (Loose: 0.0614, Midium: 0.3093, Tight: 0.7221)
+  //const double minBjetBDiscr_ = 0.5803; // FIXME: 2017 CSVv2, Loose Working Point (Midium: 0.8838, Tight: 0.9693)
   const double maxMuonRelIso_ = 0.15;
   const double maxVetoMuonRelIso_ = 0.25;
 
@@ -143,7 +144,7 @@ private:
 
   TRAF in_Jet_p4[4];
   TRAI in_Jet_id = nullptr;
-  TRAF in_Jet_CSVv2 = nullptr;
+  TRAF in_Jet_DeepFlavB = nullptr;
 
 private:
   bool _doCppOutput = false;
@@ -172,7 +173,7 @@ private:
   unsigned short out_nVetoMuon;
   unsigned short out_nGoodJet, out_nBjet;
   std::vector<float> out_GoodJet_p4[4];
-  std::vector<float> out_GoodJet_CSVv2;
+  std::vector<float> out_GoodJet_DeepFlavB;
   std::vector<unsigned short> out_GoodJet_index;
 
 };

--- a/TopAnalysis/python/postprocessing/btagWeightProducer.py
+++ b/TopAnalysis/python/postprocessing/btagWeightProducer.py
@@ -9,7 +9,7 @@ class btagWeightProducer(Module, object):
         #super(TTbarDoubleLepton, self).__init__(*args, **kwargs)
         self.jetIndexBrName = kwargs["jetIndex"] if "jetIndex" in kwargs else ""
 
-        sfName = "Jet_btagSF_shape" if "btagAlgo" not in kwargs else kwargs["btagAlgo"]
+        sfName = "Jet_btagSF_deepjet_shape" if "btagAlgo" not in kwargs else kwargs["btagAlgo"]
         self.sfNames = [sfName]
         for syst in ["jes", "lf", "hf", "hfstats1", "hfstats2", "lfstats1", "lfstats2", "cferr1", "cferr2"]:
             for d in ["up", "down"]:

--- a/TopAnalysis/python/postprocessing/fcncKinematicReco.py
+++ b/TopAnalysis/python/postprocessing/fcncKinematicReco.py
@@ -119,15 +119,21 @@ class FCNCKinematicReco(Module, object):
             qvar = TLorentzVector()
             bvar.SetPtEtaPhiM(event._tree.b_out_GoodJet_pt[0], event._tree.b_out_GoodJet_eta[0], event._tree.b_out_GoodJet_phi[0], event._tree.b_out_GoodJet_mass[0])
             qvar.SetPtEtaPhiM(event._tree.b_out_GoodJet_pt[1], event._tree.b_out_GoodJet_eta[1], event._tree.b_out_GoodJet_phi[1], event._tree.b_out_GoodJet_mass[1])
-            bjetCSV, qjetCSV = event._tree.b_out_GoodJet_CSVv2[0], event._tree.b_out_GoodJet_CSVv2[1]
+            #bjetCSV, qjetCSV = event._tree.b_out_GoodJet_CSVv2[0], event._tree.b_out_GoodJet_CSVv2[1]
+            bjetDeepFlavB, qjetDeepFlavB = event._tree.b_out_GoodJet_DeepFlavB[0], event._tree.b_out_GoodJet_DeepFlavB[1]
             # Variable condtruct : Neutrino vars = [MET, phi]
             metvar = TLorentzVector()
             metvar.SetPtEtaPhiM(event._tree.b_out_MET_pt, 0, event._tree.b_out_MET_phi, 0)
 
+            ## b jet assign by CSVv2 discriminator
+            #if ( bjetCSV < qjetCSV ):
+            #    bvar, qvar = qvar, bvar
+            #    bjetCSV, qjetCSV = qjetCSV, bjetCSV
+
             # b jet assign by CSVv2 discriminator
-            if ( bjetCSV < qjetCSV ):
+            if ( bjetDeepFlavB < qjetDeepFlavB ):
                 bvar, qvar = qvar, bvar
-                bjetCSV, qjetCSV = qjetCSV, bjetCSV
+                bjetDeepFlavB, qjetDeepFlavB = qjetDeepFlavB, bjetDeepFlavB
 
             # pxyzE calculation & construction : [px, py, pz, E]
             Zlep1 = self.getKinVar(Zlep1var.Pt(), Zlep1var.Eta(), Zlep1var.Phi(), 0.)

--- a/TopAnalysis/python/postprocessing/fcncTriLepton.py
+++ b/TopAnalysis/python/postprocessing/fcncTriLepton.py
@@ -52,7 +52,7 @@ class FCNCTriLepton(Module, object):
         self.out.branch("nGoodMuon", "i")
         #self.out.branch("nGoodJet", "i")
         self.out.branch("GoodJet_index", "i", lenVar="nGoodJet")
-        for varName in ["pt", "eta", "phi", "mass", "CSVv2"]:
+        for varName in ["pt", "eta", "phi", "mass", "DeepFlavB"]:
             self.out.branch("GoodJet_%s" % varName, "F", lenVar="nGoodJet")
         self.out.branch("nBjet", "i")
         self.out.branch("W_MT", "F")
@@ -81,7 +81,7 @@ class FCNCTriLepton(Module, object):
         objName = "Jet"
         setattr(self, "b_n%s" % objName, tree.valueReader("n%s" % objName))
         for varName in ["pt", "eta", "phi", "mass",
-                        "jetId", "puId", "btagCSVV2",]:
+                        "jetId", "puId", "btagDeepFlavB",]:
             setattr(self, "b_%s_%s" % (objName, varName), tree.arrayReader("%s_%s" % (objName, varName)))
 
         self.worker.setMET(self.b_MET_pt, self.b_MET_phi)
@@ -91,7 +91,7 @@ class FCNCTriLepton(Module, object):
         self.worker.setMuons(self.b_Muon_pt, self.b_Muon_eta, self.b_Muon_phi, self.b_Muon_mass, self.b_Muon_charge,
                              self.b_Muon_pfRelIso04_all, self.b_Muon_tightId, self.b_Muon_isGlobal, self.b_Muon_isPFcand, self.b_Muon_isTracker)
         self.worker.setJets(self.b_Jet_pt, self.b_Jet_eta, self.b_Jet_phi, self.b_Jet_mass,
-                            self.b_Jet_jetId, self.b_Jet_btagCSVV2)
+                            self.b_Jet_jetId, self.b_Jet_btagDeepFlavB)
         self._ttreereaderversion = tree._ttreereaderversion
 
         pass
@@ -109,7 +109,7 @@ class FCNCTriLepton(Module, object):
                         "TriLepton_mass", "TriLepton_pt", "TriLepton_WleptonZdPhi", "TriLepton_WleptonZdR",
                         "nVetoLepton", "nGoodElectron", "nGoodMuon", "nGoodLepton", "GoodLeptonCode", "Z_charge", "W_MT",
                         #"nGoodJet", #We do not keep nGoodJet here, it have to be done by the framework
-                        "GoodJet_index", "GoodJet_CSVv2",
+                        "GoodJet_index", "GoodJet_DeepFlavB",
                         "nBjet",]:
             setattr(event._tree, "b_out_%s" % (varName), getattr(self.worker, 'get_%s' % (varName))())
             self.out.fillBranch(varName, getattr(event._tree, "b_out_%s" % varName))

--- a/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
+++ b/TopAnalysis/src/FCNCTriLeptonCppWorker.cc
@@ -53,12 +53,12 @@ void FCNCTriLeptonCppWorker::setMuons(TRAF pt, TRAF eta, TRAF phi, TRAF mass, TR
 }
 
 void FCNCTriLeptonCppWorker::setJets(TRAF pt, TRAF eta, TRAF phi, TRAF mass,
-                                         TRAI id, TRAF CSVv2) {
+                                         TRAI id, TRAF DeepFlavB) {
   in_Jet_p4[0] = pt;
   in_Jet_p4[1] = eta;
   in_Jet_p4[2] = phi;
   in_Jet_p4[3] = mass;
-  in_Jet_CSVv2 = CSVv2;
+  in_Jet_DeepFlavB = DeepFlavB;
   in_Jet_id = id;
 }
 
@@ -84,7 +84,7 @@ void FCNCTriLeptonCppWorker::resetValues() {
   out_nVetoElectron = out_nVetoMuon = 0;
   out_nGoodJet = out_nBjet = 0;
   for ( int i=0; i<4; ++i ) out_GoodJet_p4[i].clear();
-  out_GoodJet_CSVv2.clear();
+  out_GoodJet_DeepFlavB.clear();
   out_GoodJet_index.clear();
 
 }
@@ -510,15 +510,15 @@ bool FCNCTriLeptonCppWorker::analyze() {
 
   // Continue to the Jets
   std::vector<unsigned short> jetIdxs;
-  jetIdxs.reserve(in_Jet_CSVv2->GetSize());
-  for ( unsigned i=0, n=in_Jet_CSVv2->GetSize(); i<n; ++i ) {
+  jetIdxs.reserve(in_Jet_DeepFlavB->GetSize());
+  for ( unsigned i=0, n=in_Jet_DeepFlavB->GetSize(); i<n; ++i ) {
     if ( !isGoodJet(i) ) continue;
     TLorentzVector jetP4 = buildP4(in_Jet_p4, i);
     if ( lepton1P4.Pt() > 0 and lepton1P4.DeltaR(jetP4) < 0.35 ) continue;
     if ( lepton2P4.Pt() > 0 and lepton2P4.DeltaR(jetP4) < 0.35 ) continue;
     if ( lepton3P4.Pt() > 0 and lepton3P4.DeltaR(jetP4) < 0.35 ) continue;
     jetIdxs.push_back(i);
-    if ( in_Jet_CSVv2->At(i) > minBjetBDiscr_ ) ++out_nBjet;
+    if ( in_Jet_DeepFlavB->At(i) > minBjetBDiscr_ ) ++out_nBjet;
   }
   out_nGoodJet = jetIdxs.size();
   // Sort jets by pt
@@ -527,7 +527,7 @@ bool FCNCTriLeptonCppWorker::analyze() {
   for ( unsigned k=0, n=out_nGoodJet; k<n; ++k ) {
     const unsigned kk = jetIdxs.at(k);
     for ( int i=0; i<4; ++i ) out_GoodJet_p4[i].push_back(in_Jet_p4[i]->At(kk));
-    out_GoodJet_CSVv2.push_back(in_Jet_CSVv2->At(kk));
+    out_GoodJet_DeepFlavB.push_back(in_Jet_DeepFlavB->At(kk));
     out_GoodJet_index.push_back(kk);
   }
 

--- a/TopAnalysis/test/fcncTriLepton/01_prod_ntuple.sh
+++ b/TopAnalysis/test/fcncTriLepton/01_prod_ntuple.sh
@@ -60,7 +60,9 @@ if [ ${DATATYPE::2} == "MC" ]; then
     ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.lepSFProducer lepSF"
     ARGS="$ARGS -I PhysicsTools.NanoAODTools.postprocessing.modules.common.puWeightProducer puWeight_${YEAR}"
 
-    ARGS="$ARGS -I PhysicsTools.NanoAODTools.postprocessing.modules.btv.btagSFProducer btagSF${YEAR}"
+    #ARGS="$ARGS -I PhysicsTools.NanoAODTools.postprocessing.modules.btv.btagSFProducer btagSF${YEAR}"
+    #Legacy: only for 2016 deepcsv or deepjet disc.
+    ARGS="$ARGS -I PhysicsTools.NanoAODTools.postprocessing.modules.btv.btagSFProducer btagSFLegacy${YEAR}" 
     ARGS="$ARGS -I TZWi.TopAnalysis.postprocessing.btagWeightProducer btagWeight"
 else
     if [ $DATATYPE == "Run2016" ]; then


### PR DESCRIPTION
As we know about b discriminator, DeepFlavour (Deepjet) is more efficient than CSVv2.
So I check the result when using the deepflavour discriminator.

First, there was no problem when I modified about btagWeightproducer (in TZWi) and btagSFproducer (in nanoAODTools).

But you need to change the btagSFproducer.py when produce the ntuple with deepflavour discriminator:
1. line 35) change the algo='csvv2' -> algo='deepjet' & selectedWPs=['M', 'shape_corr'] -> selectedWPs=['L', 'shape_corr']
2. after line 325) adding the new lambda function "btagSFLegacy2016" because key of deepjet for 2016 name is "Legacy2016"
