### PR TITLE
TMVA evaluation to get shape

### DIFF
--- a/TopAnalysis/test/fcncTriLepton/TMVA/TMVAEvaluation_bdt.py
+++ b/TopAnalysis/test/fcncTriLepton/TMVA/TMVAEvaluation_bdt.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python
+import os, sys
+from ROOT import *
+from glob import glob
+from array import array
+import numpy as np
+import yaml
+from variables import input_TT_bdt, input_ST_bdt
+
+# Import TMVA classes from ROOT
+TMVA.Tools.Instance()
+
+if len(sys.argv) < 2:
+    print("Not enough arguments: channel, mode")
+    print("Select one of the channel = TTZct, TTZut, STZct, STZut")
+    print("Select one of the mode = ElElEl, MuElEl, MuMuMu, ElMuMu")
+    print("Usage: python TMVAEvaluation_bdt.py TTZct ElElEl")
+    sys.exit()
+channel = sys.argv[1]
+mode = sys.argv[2]
+
+weight_bkg_case = 'WZ_ZZ'
+# Weight outfile after classification in TT signal: channel_mode_WZ_ZZ_Tr7Te3/TMVAClassification_BDTG_TT.weights.xml
+
+rootDir = '%s/src/TZWi/TopAnalysis/test/fcncTriLepton/' % os.environ["CMSSW_BASE"]
+kisti_store = '/xrootd/store/user/heewon/'
+ntupleDir = 'ntuple_2016'
+weightDir = 'TMVA/dataset/result_%s_%s_%s_Tr7Te3' % (channel, mode, weight_bkg_case)
+scoreDir = 'TMVA/scores/%s/%s_%s' % (channel, mode, weight_bkg_case)
+
+#'title' in the groupting.yaml
+#bkg_others = ["DYJets", "SingleTop", "ttJets", "WW", "SingleTopV", "ttV", "ttH"]
+
+procInfo = yaml.load(open(rootDir+"config/grouping.yaml").read())["processes"]
+datasetInfo = {}
+for f in glob(rootDir+"config/datasets/*16*.yaml"):
+      if 'dataset' not in datasetInfo: datasetInfo["dataset"] = {}
+      datasetInfo["dataset"].update(yaml.load(open(f).read())["dataset"])
+
+#for mc syst name
+syst = ["origin", "jesUp", "jesDown", "jerUp", "jerDown"]
+syst_forWeight = ["genWeight", "Electron_SF", "Electron_SFerr", "MuonID_SF", "MuonID_SFerr", "MuonISO_SF", "MuonISO_SFerr", "Trigger_SF", "puWeight", "puWeightUp", "puWeightDown", "BtagWeight"]
+#weight from origin: "LHEScaleWeight[4]*genWeight/abs(genWeight)*puWeight*BtagWeight*Trigger_SF*Electron_SF*MuonID_SF*MuonISO_SF
+#ElSF up/down -> up/down: Electron_SF +- Electron_SFerr
+#MuID up/down -> up/down: MuonID_SF +- MuonID_SFerr
+#MuISO up/down -> up/down: MuonISO_SF +- MuonISO_SFerr
+#syst_lepSF = ["ElSFUp", "ElSFDown", "MuIDUp", "MuIDDown", "MuISOUp", "MuISODown"]
+#MuR up / down -> LHEScaleWeight[7] / [1]
+#MuF up/down -> LHEScaleWeight[5] / [3]
+#syst_theory = ["MuRUp", "MuRDown", "MuFUp", "MuFDown"]
+
+#fLists_input = []
+#We need to different variables for mva input by channel
+input_features = []
+if channel == "TTZct" or channel == "TTZut":
+    input_features.extend(input_TT_bdt(channel))
+elif channel == "STZct" or channel == "STZut":
+    input_features.extend(input_ST_bdt(channel))
+# Outfile will be processed by dataset from each syst
+#for each_bkg in bkg_others:
+#channel = sys.argv[1], mode = sys.argv[2]
+for systjet in syst:
+    if systjet == "jesUp":
+        ntupleDir = 'FCNC_2016_jesTotalUp'
+        dName = kisti_store + ntupleDir
+    elif systjet == "jesDown":
+        ntupleDir = 'FCNC_2016_jesTotalDown'
+        dName = kisti_store + ntupleDir
+    elif systjet == "jerUp":
+        ntupleDir = 'FCNC_2016_jerUp'
+        dName = kisti_store + ntupleDir
+    elif systjet == "jerDown":
+        ntupleDir = 'FCNC_2016_jerDown'
+        dName = kisti_store + ntupleDir
+    else:
+        dName = rootDir + ntupleDir
+    if not os.path.exists( os.path.join(rootDir,scoreDir,systjet) ):
+        os.makedirs( os.path.join(rootDir,scoreDir,systjet) )
+
+    for proc in procInfo:
+        #if each_bkg == procInfo[proc]['title']:
+        #for each_mc in procInfo[proc]['title']:
+        #if not "Data" in procInfo[proc]['title']:
+        for datasetGroup in procInfo[proc]['datasets']:
+            #print procInfo[proc]['modes'][0]
+            if "Data" not in procInfo[proc]['title']:
+                #datasetGroup = "MC2016.~~"
+                outputFile = TFile.Open( os.path.join(rootDir,scoreDir,systjet, 'score_TMVA_'+ datasetGroup[7:] + '.root'), 'RECREATE' )
+            elif ("Data" in procInfo[proc]['title']) and mode == procInfo[proc]['modes'][0] and ("NPL" not in procInfo[proc]['modes'][0]) and systjet=="origin":
+                #datasetGroup = "Run2016.~~"
+                print proc
+                outputFile = TFile.Open( os.path.join(rootDir,scoreDir,systjet, 'score_TMVA_'+ datasetGroup[8:] + '.root'), 'RECREATE' )
+            else: continue
+            out_tree = TTree("Events", "Events")
+            fLists_input = []
+            for datasetName in datasetInfo['dataset'][datasetGroup].keys():
+                fLists_input.append(glob(dName+"/reco/%s/%s" % (mode, datasetName[1:].replace('/','.'))))
+
+            reader = TMVA.Reader("Color:!Silent") #coloured output & not suppression all output
+            input_tree = TChain("Events")
+            for fsig in fLists_input:
+                print fsig[0]
+                file_list = os.listdir(fsig[0])
+                for file_l in file_list:
+                    #f = TFile.Open(os.path.join(fsig[0],file_l))
+                    #input_tree = f.Get("Events")
+                    f = os.path.join(fsig[0],file_l)
+                    input_tree.Add(f)
+
+            branches = {}
+            for branch in input_tree.GetListOfBranches():
+                branchName = branch.GetName()
+                if branchName in input_features:
+                    branches[branchName] = array('f', [-999])
+                    reader.AddVariable(branchName, branches[branchName])
+                    input_tree.SetBranchAddress(branchName, branches[branchName])
+                if branchName in ["LeadingLepton_pt", "Z_charge", "nGoodLepton", "GoodLeptonCode", "MVAinput_Status"]:
+                    branches[branchName] = array('f', [-999])
+                    reader.AddSpectator(branchName, branches[branchName])
+                if branchName in ["HLT", "nGoodJet", "nBjet"]:
+                    branches[branchName] = array('f', [-999])
+                    input_tree.SetBranchAddress(branchName, branches[branchName])
+                if branchName in syst_forWeight:
+                    branches[branchName] = array('f', [-999])
+                    input_tree.SetBranchAddress(branchName, branches[branchName])
+
+            if channel == "TTZct" or channel == "TTZut":
+                reader.BookMVA('BDTG_TT', TString(os.path.join(rootDir,weightDir,'TMVAClassification_BDTG_TT.weights.xml')))
+            elif channel == "STZct" or channel == "STZut":
+                reader.BookMVA('BDTG_ST', TString(os.path.join(rootDir,weightDir,'TMVAClassification_BDTG_ST.weights.xml')))
+            totevent = input_tree.GetEntries()
+
+            score = np.zeros(1, dtype=np.float32)
+            nEvent = np.zeros(1, dtype=int)
+            nGoodLepton = np.zeros(1, dtype=int)
+            LeadingLepton_pt = np.zeros(1, dtype=np.float32)
+            Z_charge = np.zeros(1, dtype=int)
+            MVAinput_Status = np.zeros(1, dtype=int)
+            # for weight
+            if "Data" not in procInfo[proc]['title']:
+                genWeight = np.zeros(1, dtype=np.float32)
+                LHEScaleWeight = np.zeros(1, dtype=np.float32)
+                LHEScaleWeight_MuRUp = np.zeros(1, dtype=np.float32)
+                LHEScaleWeight_MuRDown = np.zeros(1, dtype=np.float32)
+                LHEScaleWeight_MuFUp = np.zeros(1, dtype=np.float32)
+                LHEScaleWeight_MuFDown = np.zeros(1, dtype=np.float32)
+                Electron_SF = np.zeros(1, dtype=np.float32)
+                Electron_SFerr = np.zeros(1, dtype=np.float32)
+                MuonID_SF = np.zeros(1, dtype=np.float32)
+                MuonID_SFerr = np.zeros(1, dtype=np.float32)
+                MuonISO_SF = np.zeros(1, dtype=np.float32)
+                MuonISO_SFerr = np.zeros(1, dtype=np.float32)
+                Trigger_SF = np.zeros(1, dtype=np.float32)
+                puWeight = np.zeros(1, dtype=np.float32)
+                puWeightUp = np.zeros(1, dtype=np.float32)
+                puWeightDown = np.zeros(1, dtype=np.float32)
+                BtagWeight = np.zeros(1, dtype=np.float64)
+
+            if "Data" not in procInfo[proc]['title']:
+                out_tree.Branch('genWeight', genWeight, 'genWeight/F')
+                out_tree.Branch('LHEScaleWeight', LHEScaleWeight, 'LHEScaleWeight/F')
+                out_tree.Branch('LHEScaleWeight_MuRUp', LHEScaleWeight_MuRUp, 'LHEScaleWeight_MuRUp/F')
+                out_tree.Branch('LHEScaleWeight_MuRDown', LHEScaleWeight_MuRDown, 'LHEScaleWeight_MuRDown/F')
+                out_tree.Branch('LHEScaleWeight_MuFUp', LHEScaleWeight_MuFUp, 'LHEScaleWeight_MuFUp/F')
+                out_tree.Branch('LHEScaleWeight_MuFDown', LHEScaleWeight_MuFDown, 'LHEScaleWeight_MuFDown/F')
+                out_tree.Branch('Electron_SF', Electron_SF, 'Electron_SF/F')
+                out_tree.Branch('Electron_SFerr', Electron_SFerr, 'Electron_SFerr/F')
+                out_tree.Branch('MuonID_SF', MuonID_SF, 'MuonID_SF/F')
+                out_tree.Branch('MuonID_SFerr', MuonID_SFerr, 'MuonID_SFerr/F')
+                out_tree.Branch('MuonISO_SF', MuonISO_SF, 'MuonISO_SF/F')
+                out_tree.Branch('MuonISO_SFerr', MuonISO_SFerr, 'MuonISO_SFerr/F')
+                out_tree.Branch('Trigger_SF', Trigger_SF, 'Trigger_SF/F')
+                out_tree.Branch('puWeight', puWeight, 'puWeight/F')
+                out_tree.Branch('puWeightUp', puWeightUp, 'puWeightUp/F')
+                out_tree.Branch('puWeightDown', puWeightDown, 'puWeightDown/F')
+                out_tree.Branch('BtagWeight', BtagWeight, 'BtagWeight/D')
+
+            out_tree.Branch('MLScore', score, 'MLScore/F')
+            out_tree.Branch('LeadingLepton_pt', LeadingLepton_pt, 'LeadingLepton_pt/F')
+            out_tree.Branch('Z_charge', Z_charge, 'Z_charge/I')
+            out_tree.Branch('nEvent', nEvent, 'nEvent/I')
+            out_tree.Branch('nGoodLepton', nGoodLepton, 'nGoodLepton/I')
+            out_tree.Branch('MVAinput_Status', MVAinput_Status, 'MVAinput_Status/i')
+
+            print totevent
+            for i in xrange(totevent):
+                input_tree.GetEntry(i)
+                if channel == "TTZct" or channel == "TTZut":
+                    #TTSR
+                    if not(input_tree.HLT == 1 and abs(input_tree.Z_mass-91.2) < 7.5 and input_tree.nGoodJet > 1 and input_tree.nGoodJet <= 3 and input_tree.nBjet >= 1 and abs(input_tree.GoodLeptonCode) == 111 and input_tree.nGoodLepton == 3 and input_tree.LeadingLepton_pt > 25 and input_tree.Z_charge == 0 and input_tree.W_MT <= 300): continue
+                    score[0] = reader.EvaluateMVA('BDTG_TT')
+                    nEvent[0] = input_tree.event
+                    nGoodLepton[0] = input_tree.nGoodLepton
+                    LeadingLepton_pt[0] = input_tree.LeadingLepton_pt
+                    Z_charge[0] = input_tree.Z_charge
+                    MVAinput_Status[0] = input_tree.MVAinput_Status
+                    if "Data" not in procInfo[proc]['title']:
+                    #MuR up / down -> LHEScaleWeight[7] / [1]
+                    #MuF up/down -> LHEScaleWeight[5] / [3]
+                        if not input_tree.LHEScaleWeight:
+                            LHEScaleWeight[0] = LHEScaleWeight_MuRUp[0] = LHEScaleWeight_MuRDown[0] = LHEScaleWeight_MuFUp[0] = LHEScaleWeight_MuFDown[0] = 0
+                            print "No LHEScaleWeight! Checking the genWeight and original LHEWeight from this input"
+                        else:
+                            LHEScaleWeight[0] = input_tree.LHEScaleWeight[4]
+                            LHEScaleWeight_MuRUp[0] = input_tree.LHEScaleWeight[7]
+                            LHEScaleWeight_MuRDown[0] = input_tree.LHEScaleWeight[1]
+                            LHEScaleWeight_MuFUp[0] = input_tree.LHEScaleWeight[5]
+                            LHEScaleWeight_MuFDown[0] = input_tree.LHEScaleWeight[3]
+                        genWeight[0] = input_tree.genWeight
+                        Electron_SF[0] = input_tree.Electron_SF
+                        Electron_SFerr[0] = input_tree.Electron_SFerr
+                        MuonID_SF[0] = input_tree.MuonID_SF
+                        MuonID_SFerr[0] = input_tree.MuonID_SFerr
+                        MuonISO_SF[0] = input_tree.MuonID_SF
+                        MuonISO_SFerr[0] = input_tree.MuonID_SFerr
+                        Trigger_SF[0] = input_tree.Trigger_SF
+                        puWeight[0] = input_tree.puWeight
+                        puWeightUp[0] = input_tree.puWeightUp
+                        puWeightDown[0] = input_tree.puWeightDown
+                        BtagWeight[0] = input_tree.BtagWeight
+                    out_tree.Fill()
+                elif channel == "STZct" or channel == "STZut":
+                    #STSR
+                    if not(input_tree.HLT == 1 and abs(input_tree.Z_mass-91.2) < 7.5 and input_tree.nGoodJet == 1 and input_tree.nBjet == 1 and abs(input_tree.GoodLeptonCode) == 111 and input_tree.nGoodLepton == 3 and input_tree.LeadingLepton_pt > 25 and input_tree.Z_charge == 0 and input_tree.W_MT <= 300): continue
+                    score[0] = reader.EvaluateMVA('BDTG_ST')
+                    nEvent[0] = input_tree.event
+                    nGoodLepton[0] = input_tree.nGoodLepton
+                    LeadingLepton_pt[0] = input_tree.LeadingLepton_pt
+                    Z_charge[0] = input_tree.Z_charge
+                    MVAinput_Status[0] = input_tree.MVAinput_Status
+                    if "Data" not in procInfo[proc]['title']:
+                        if not input_tree.LHEScaleWeight:
+                            LHEScaleWeight[0] = LHEScaleWeight_MuRUp[0] = LHEScaleWeight_MuRDown[0] = LHEScaleWeight_MuFUp[0] = LHEScaleWeight_MuFDown[0] = 0
+                            print "No LHEScaleWeight! Checking the genWeight and original LHEWeight from this input"
+                        else:
+                            LHEScaleWeight[0] = input_tree.LHEScaleWeight[4]
+                            LHEScaleWeight_MuRUp[0] = input_tree.LHEScaleWeight[7]
+                            LHEScaleWeight_MuRDown[0] = input_tree.LHEScaleWeight[1]
+                            LHEScaleWeight_MuFUp[0] = input_tree.LHEScaleWeight[5]
+                            LHEScaleWeight_MuFDown[0] = input_tree.LHEScaleWeight[3]
+                        genWeight[0] = input_tree.genWeight
+                        Electron_SF[0] = input_tree.Electron_SF
+                        Electron_SFerr[0] = input_tree.Electron_SFerr
+                        MuonID_SF[0] = input_tree.MuonID_SF
+                        MuonID_SFerr[0] = input_tree.MuonID_SFerr
+                        MuonISO_SF[0] = input_tree.MuonID_SF
+                        MuonISO_SFerr[0] = input_tree.MuonID_SFerr
+                        Trigger_SF[0] = input_tree.Trigger_SF
+                        puWeight[0] = input_tree.puWeight
+                        puWeightUp[0] = input_tree.puWeightUp
+                        puWeightDown[0] = input_tree.puWeightDown
+                        BtagWeight[0] = input_tree.BtagWeight
+                    out_tree.Fill()
+
+            score[0] = -1
+            nEvent[0] = 0
+            nGoodLepton[0] = 0
+            LeadingLepton_pt[0] = 0
+            Z_charge[0] = 0
+            MVAinput_Status[0] = 0
+            if "Data" not in procInfo[proc]['title']:
+                LHEScaleWeight[0] = 0
+                LHEScaleWeight_MuRUp[0] = 0
+                LHEScaleWeight_MuRDown[0] = 0
+                LHEScaleWeight_MuFUp[0] = 0
+                LHEScaleWeight_MuFDown[0] = 0
+                genWeight[0] = 0
+                Electron_SF[0] = Electron_SFerr[0] = 0
+                MuonID_SF[0] = MuonID_SFerr[0] = MuonISO_SF[0] = MuonISO_SFerr[0] = 0
+                Trigger_SF[0] = 0
+                puWeight[0] = puWeightUp[0] = puWeightDown[0] = 0
+                BtagWeight[0] = 0
+
+            outputFile.Write()
+            outputFile.Close()
+

--- a/TopAnalysis/test/fcncTriLepton/TMVA/TMVAEvaluation_btagWeight.py
+++ b/TopAnalysis/test/fcncTriLepton/TMVA/TMVAEvaluation_btagWeight.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python
+import os, sys
+from ROOT import *
+from glob import glob
+from array import array
+import numpy as np
+import yaml
+from variables import input_TT_bdt, input_ST_bdt
+
+# Import TMVA classes from ROOT
+TMVA.Tools.Instance()
+
+if len(sys.argv) < 2:
+#-C TTZct -M MuMuMu -m BDTG200t1 -o TTZct_MuMuMu_except_WZ_ZZ_Tr7Te3
+    print("Not enough arguments: channel, mode")
+    print("Select one of the channel = TTZct, TTZut, STZct, STZut")
+    print("Select one of the mode = ElElEl, MuElEl, MuMuMu, ElMuMu")
+    print("Usage: python TMVAEvaluation_bdt.py TTZct ElElEl")
+    sys.exit()
+channel = sys.argv[1]
+mode = sys.argv[2]
+
+weight_bkg_case = 'WZ_ZZ'
+# Weight outfile after classification in TT signal: channel_mode_WZ_ZZ_Tr7Te3/TMVAClassification_BDTG_TT.weights.xml
+
+rootDir = '%s/src/TZWi/TopAnalysis/test/fcncTriLepton/' % os.environ["CMSSW_BASE"]
+kisti_store = '/xrootd/store/user/heewon/'
+ntupleDir = 'ntuple_2016'
+weightDir = 'TMVA/dataset/result_%s_%s_%s_Tr7Te3' % (channel, mode, weight_bkg_case)
+scoreDir = 'TMVA/scores/%s/%s_%s' % (channel, mode, weight_bkg_case)
+
+#'title' in the groupting.yaml
+#bkg_others = ["DYJets", "SingleTop", "ttJets", "WW", "SingleTopV", "ttV", "ttH"]
+
+procInfo = yaml.load(open(rootDir+"config/grouping.yaml").read())["processes"]
+datasetInfo = {}
+for f in glob(rootDir+"config/datasets/*16*.yaml"):
+      if 'dataset' not in datasetInfo: datasetInfo["dataset"] = {}
+      datasetInfo["dataset"].update(yaml.load(open(f).read())["dataset"])
+
+#for mc syst name
+#syst = ["origin", "jesup", "jesdown", "jerup", "jerdown"]
+#for btag weight
+syst = ["origin"]
+syst_btagshape = ["BtagWeight_btagSF_deepjet_shape_up_jes", "BtagWeight_btagSF_deepjet_shape_down_jes",
+                 "BtagWeight_btagSF_deepjet_shape_up_lf", "BtagWeight_btagSF_deepjet_shape_down_lf",
+                 "BtagWeight_btagSF_deepjet_shape_up_hf", "BtagWeight_btagSF_deepjet_shape_down_hf",
+                 "BtagWeight_btagSF_deepjet_shape_up_hfstats1", "BtagWeight_btagSF_deepjet_shape_down_hfstats1",
+                 "BtagWeight_btagSF_deepjet_shape_up_hfstats2", "BtagWeight_btagSF_deepjet_shape_down_hfstats2",
+                 "BtagWeight_btagSF_deepjet_shape_up_lfstats1", "BtagWeight_btagSF_deepjet_shape_down_lfstats1",
+                 "BtagWeight_btagSF_deepjet_shape_up_lfstats2", "BtagWeight_btagSF_deepjet_shape_down_lfstats2",
+                 "BtagWeight_btagSF_deepjet_shape_up_cferr1", "BtagWeight_btagSF_deepjet_shape_down_cferr1",
+                 "BtagWeight_btagSF_deepjet_shape_up_cferr2", "BtagWeight_btagSF_deepjet_shape_down_cferr2"]
+syst_forWeight = ["Electron_SF", "Electron_SFerr", "MuonID_SF", "MuonID_SFerr", "MuonISO_SF", "MuonISO_SFerr", "Trigger_SF", "puWeight", "puWeightUp", "puWeightDown", "BtagWeight"]
+#weight from origin: "LHEScaleWeight[4]*genWeight/abs(genWeight)*puWeight*BtagWeight*Trigger_SF*Electron_SF*MuonID_SF*MuonISO_SF
+#ElSF up/down -> up/down: Electron_SF +- Electron_SFerr
+#MuID up/down -> up/down: MuonID_SF +- MuonID_SFerr
+#MuISO up/down -> up/down: MuonISO_SF +- MuonISO_SFerr
+#syst_lepSF = ["ElSFUp", "ElSFDown", "MuIDUp", "MuIDDown", "MuISOUp", "MuISODown"]
+#MuR up / down -> LHEScaleWeight[7] / [1]
+#MuF up/down -> LHEScaleWeight[5] / [3]
+#syst_theory = ["MuRUp", "MuRDown", "MuFUp", "MuFDown"]
+
+#fLists_input = []
+#We need to different variables for mva input by channel
+input_features = []
+if channel == "TTZct" or channel == "TTZut":
+    input_features.extend(input_TT_bdt(channel))
+elif channel == "STZct" or channel == "STZut":
+    input_features.extend(input_ST_bdt(channel))
+# Outfile will be processed by dataset from each syst
+#for each_bkg in bkg_others:
+#channel = sys.argv[1], mode = sys.argv[2]
+for systjet in syst:
+    if systjet == "jesup":
+        ntupleDir = 'FCNC_2016_jesTotalUp'
+        dName = kisti_store + ntupleDir
+    elif systjet == "jesdown":
+        ntupleDir = 'FCNC_2016_jesTotalDown'
+        dName = kisti_store + ntupleDir
+    elif systjet == "jerup":
+        ntupleDir = 'FCNC_2016_jerUp'
+        dName = kisti_store + ntupleDir
+    elif systjet == "jerdown":
+        ntupleDir = 'FCNC_2016_jerDown'
+        dName = kisti_store + ntupleDir
+    else:
+        dName = rootDir + ntupleDir
+    #if not os.path.exists( os.path.join(rootDir,scoreDir,systjet) ):
+    #    os.makedirs( os.path.join(rootDir,scoreDir,systjet) )
+
+    for proc in procInfo:
+        #if each_bkg == procInfo[proc]['title']:
+        #for each_mc in procInfo[proc]['title']:
+        #if not "Data" in procInfo[proc]['title']:
+        for datasetGroup in procInfo[proc]['datasets']:
+            #print procInfo[proc]['modes'][0]
+            if "Data" not in procInfo[proc]['title']:
+                #datasetGroup = "MC2016.~~"
+                #outputFile = TFile.Open( os.path.join(rootDir,scoreDir,systjet, 'score_TMVA_'+ datasetGroup[7:] + '.root'), 'RECREATE' )
+                outputFile = TFile.Open( os.path.join(rootDir,scoreDir,systjet, 'score_TMVA_'+ datasetGroup[7:] + '.root'), 'UPDATE' )
+            #elif ("Data" in procInfo[proc]['title']) and mode == procInfo[proc]['modes'][0] and ("NPL" not in procInfo[proc]['modes'][0]) and systjet=="origin":
+            #    #datasetGroup = "Run2016.~~"
+            #    print proc
+            #    outputFile = TFile.Open( os.path.join(rootDir,scoreDir,systjet, 'score_TMVA_'+ datasetGroup[8:] + '.root'), 'RECREATE' )
+            else: continue
+            out_tree = TTree("EventsBtag", "EventsBtag")
+            #out_tree = outputFile.Get("Events")
+            fLists_input = []
+            for datasetName in datasetInfo['dataset'][datasetGroup].keys():
+                fLists_input.append(glob(dName+"/reco/%s/%s" % (mode, datasetName[1:].replace('/','.'))))
+
+            #reader = TMVA.Reader("Color:!Silent") #coloured output & not suppression all output
+            input_tree = TChain("Events")
+            for fsig in fLists_input:
+                print fsig[0]
+                file_list = os.listdir(fsig[0])
+                for file_l in file_list:
+                    #f = TFile.Open(os.path.join(fsig[0],file_l))
+                    #input_tree = f.Get("Events")
+                    f = os.path.join(fsig[0],file_l)
+                    input_tree.Add(f)
+
+            branches = {}
+            for branch in input_tree.GetListOfBranches():
+                branchName = branch.GetName()
+                if branchName in input_features:
+                    branches[branchName] = array('f', [-999])
+                    #reader.AddVariable(branchName, branches[branchName])
+                    input_tree.SetBranchAddress(branchName, branches[branchName])
+                #if branchName in ["LeadingLepton_pt", "Z_charge", "nGoodLepton", "GoodLeptonCode", "MVAinput_Status"]:
+                #    branches[branchName] = array('f', [-999])
+                #    reader.AddSpectator(branchName, branches[branchName])
+                #if branchName in ["HLT", "nGoodJet", "nBjet"]:
+                #    branches[branchName] = array('f', [-999])
+                #    input_tree.SetBranchAddress(branchName, branches[branchName])
+                #if branchName in syst_forWeight:
+                #    branches[branchName] = array('f', [-999])
+                #    input_tree.SetBranchAddress(branchName, branches[branchName])
+                if branchName in syst_btagshape and systjet == "origin":
+                    branches[branchName] = array('d', [-999])
+                    input_tree.SetBranchAddress(branchName, branches[branchName])
+
+            #if channel == "TTZct" or channel == "TTZut":
+            #    reader.BookMVA('BDTG_TT', TString(os.path.join(rootDir,weightDir,'TMVAClassification_BDTG_TT.weights.xml')))
+            #elif channel == "STZct" or channel == "STZut":
+            #    reader.BookMVA('BDTG_ST', TString(os.path.join(rootDir,weightDir,'TMVAClassification_BDTG_ST.weights.xml')))
+            totevent = input_tree.GetEntries()
+
+            # for weight
+            if "Data" not in procInfo[proc]['title']:
+                if systjet == "origin":
+                # for weight - btagshape
+                    BtagWeight_jesup = np.zeros(1, dtype=np.float64)
+                    BtagWeight_jesdown = np.zeros(1, dtype=np.float64)
+                    BtagWeight_lfup = np.zeros(1, dtype=np.float64)
+                    BtagWeight_lfdown = np.zeros(1, dtype=np.float64)
+                    BtagWeight_hfup = np.zeros(1, dtype=np.float64)
+                    BtagWeight_hfdown = np.zeros(1, dtype=np.float64)
+                    BtagWeight_lfstats1up = np.zeros(1, dtype=np.float64)
+                    BtagWeight_lfstats1down = np.zeros(1, dtype=np.float64)
+                    BtagWeight_hfstats1up = np.zeros(1, dtype=np.float64)
+                    BtagWeight_hfstats1down = np.zeros(1, dtype=np.float64)
+                    BtagWeight_lfstats2up = np.zeros(1, dtype=np.float64)
+                    BtagWeight_lfstats2down = np.zeros(1, dtype=np.float64)
+                    BtagWeight_hfstats2up = np.zeros(1, dtype=np.float64)
+                    BtagWeight_hfstats2down = np.zeros(1, dtype=np.float64)
+                    BtagWeight_cferr1up = np.zeros(1, dtype=np.float64)
+                    BtagWeight_cferr1down = np.zeros(1, dtype=np.float64)
+                    BtagWeight_cferr2up = np.zeros(1, dtype=np.float64)
+                    BtagWeight_cferr2down = np.zeros(1, dtype=np.float64)
+
+            if "Data" not in procInfo[proc]['title']:
+                if systjet == "origin":
+                    out_tree.Branch('BtagWeight_jesup', BtagWeight_jesup, 'BtagWeight_jesup/D')
+                    out_tree.Branch('BtagWeight_jesdown', BtagWeight_jesdown, 'BtagWeight_jesdown/D')
+                    out_tree.Branch('BtagWeight_lfup', BtagWeight_lfup, 'BtagWeight_lfup/D')
+                    out_tree.Branch('BtagWeight_lfdown', BtagWeight_lfdown, 'BtagWeight_lfdown/D')
+                    out_tree.Branch('BtagWeight_hfup', BtagWeight_hfup, 'BtagWeight_hfup/D')
+                    out_tree.Branch('BtagWeight_hfdown', BtagWeight_hfdown, 'BtagWeight_hfdown/D')
+                    out_tree.Branch('BtagWeight_lfstats1up', BtagWeight_lfstats1up, 'BtagWeight_lfstats1up/D')
+                    out_tree.Branch('BtagWeight_lfstats1down', BtagWeight_lfstats1down, 'BtagWeight_lfstats1down/D')
+                    out_tree.Branch('BtagWeight_hfstats1up', BtagWeight_hfstats1up, 'BtagWeight_hfstats1up/D')
+                    out_tree.Branch('BtagWeight_hfstats1down', BtagWeight_hfstats1down, 'BtagWeight_hfstats1down/D')
+                    out_tree.Branch('BtagWeight_lfstats2up', BtagWeight_lfstats2up, 'BtagWeight_lfstats2up/D')
+                    out_tree.Branch('BtagWeight_lfstats2down', BtagWeight_lfstats2down, 'BtagWeight_lfstats2down/D')
+                    out_tree.Branch('BtagWeight_hfstats2up', BtagWeight_hfstats2up, 'BtagWeight_hfstats2up/D')
+                    out_tree.Branch('BtagWeight_hfstats2down', BtagWeight_hfstats2down, 'BtagWeight_hfstats2down/D')
+                    out_tree.Branch('BtagWeight_cferr1up', BtagWeight_cferr1up, 'BtagWeight_cferr1up/D')
+                    out_tree.Branch('BtagWeight_cferr1down', BtagWeight_cferr1down, 'BtagWeight_cferr1down/D')
+                    out_tree.Branch('BtagWeight_cferr2up', BtagWeight_cferr2up, 'BtagWeight_cferr2up/D')
+                    out_tree.Branch('BtagWeight_cferr2down', BtagWeight_cferr2down, 'BtagWeight_cferr2down/D')
+
+            print totevent
+            for i in xrange(totevent):
+                input_tree.GetEntry(i)
+                if channel == "TTZct" or channel == "TTZut":
+                    #TTSR
+                    if not(input_tree.HLT == 1 and abs(input_tree.Z_mass-91.2) < 7.5 and input_tree.nGoodJet > 1 and input_tree.nGoodJet <= 3 and input_tree.nBjet >= 1 and abs(input_tree.GoodLeptonCode) == 111 and input_tree.nGoodLepton == 3 and input_tree.LeadingLepton_pt > 25 and input_tree.Z_charge == 0 and input_tree.W_MT <= 300): continue
+                    if "Data" not in procInfo[proc]['title']:
+                        if systjet == "origin":
+                            BtagWeight_jesup[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_jes
+                            BtagWeight_jesdown[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_jes
+                            BtagWeight_lfup[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_lf
+                            BtagWeight_lfdown[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_lf
+                            BtagWeight_hfup[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_hf
+                            BtagWeight_hfdown[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_hf
+                            BtagWeight_lfstats1up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_lfstats1
+                            BtagWeight_lfstats1down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_lfstats1
+                            BtagWeight_hfstats1up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_hfstats1
+                            BtagWeight_hfstats1down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_hfstats1
+                            BtagWeight_lfstats2up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_lfstats2
+                            BtagWeight_lfstats2down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_lfstats2
+                            BtagWeight_hfstats2up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_hfstats2
+                            BtagWeight_hfstats2down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_hfstats2
+                            BtagWeight_cferr1up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_cferr1
+                            BtagWeight_cferr1down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_cferr1
+                            BtagWeight_cferr2up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_cferr2
+                            BtagWeight_cferr2down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_cferr2
+                    out_tree.Fill()
+                elif channel == "STZct" or channel == "STZut":
+                    #STSR
+                    if not(input_tree.HLT == 1 and abs(input_tree.Z_mass-91.2) < 7.5 and input_tree.nGoodJet == 1 and input_tree.nBjet == 1 and abs(input_tree.GoodLeptonCode) == 111 and input_tree.nGoodLepton == 3 and input_tree.LeadingLepton_pt > 25 and input_tree.Z_charge == 0 and input_tree.W_MT <= 300): continue
+                    if "Data" not in procInfo[proc]['title']:
+                        if systjet == "origin":
+                            BtagWeight_jesup[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_jes
+                            BtagWeight_jesdown[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_jes
+                            BtagWeight_lfup[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_lf
+                            BtagWeight_lfdown[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_lf
+                            BtagWeight_hfup[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_hf
+                            BtagWeight_hfdown[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_hf
+                            BtagWeight_lfstats1up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_lfstats1
+                            BtagWeight_lfstats1down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_lfstats1
+                            BtagWeight_hfstats1up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_hfstats1
+                            BtagWeight_hfstats1down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_hfstats1
+                            BtagWeight_lfstats2up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_lfstats2
+                            BtagWeight_lfstats2down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_lfstats2
+                            BtagWeight_hfstats2up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_hfstats2
+                            BtagWeight_hfstats2down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_hfstats2
+                            BtagWeight_cferr1up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_cferr1
+                            BtagWeight_cferr1down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_cferr1
+                            BtagWeight_cferr2up[0] = input_tree.BtagWeight_btagSF_deepjet_shape_up_cferr2
+                            BtagWeight_cferr2down[0] = input_tree.BtagWeight_btagSF_deepjet_shape_down_cferr2
+                    out_tree.Fill()
+
+            if "Data" not in procInfo[proc]['title']:
+                if systjet == "origin":
+                    BtagWeight_jesup[0] = BtagWeight_jesdown[0] = 0
+                    BtagWeight_lfup[0] = BtagWeight_lfdown[0] = BtagWeight_hfup[0] = BtagWeight_hfdown[0] = 0
+                    BtagWeight_lfstats1up[0] = BtagWeight_lfstats1down[0] = BtagWeight_hfstats1up[0] = BtagWeight_hfstats1down[0] = 0
+                    BtagWeight_lfstats2up[0] = BtagWeight_lfstats2down[0] = BtagWeight_hfstats2up[0] = BtagWeight_hfstats2down[0] = 0
+                    BtagWeight_cferr1up[0] = BtagWeight_cferr1down[0] = BtagWeight_cferr2up[0] = BtagWeight_cferr2down[0] = 0
+
+            outputFile.Write()
+            outputFile.Close()
+

--- a/TopAnalysis/test/fcncTriLepton/TMVA/getShape.py
+++ b/TopAnalysis/test/fcncTriLepton/TMVA/getShape.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+import yaml
+import sys, os
+from ROOT import *
+from glob import glob
+from array import array
+
+if __name__ == '__main__':
+
+    # Read input data
+    rootDir = '%s/src/TZWi/TopAnalysis/test/fcncTriLepton/' % os.environ["CMSSW_BASE"]
+    scoreDir = 'TMVA/scores'
+    dName = rootDir + scoreDir
+    syst = ["origin", "jesUp", "jesDown", "jerUp", "jerDown"]
+    syst_btagshape = ["BtagWeight_jesup", "BtagWeight_jesdown",
+                 "BtagWeight_lfup", "BtagWeight_lfdown", "BtagWeight_hfup", "BtagWeight_hfdown",
+                 "BtagWeight_hfstats1up", "BtagWeight_hfstats1down", "BtagWeight_hfstats2up", "BtagWeight_hfstats2down",
+                 "BtagWeight_lfstats1up", "BtagWeight_lfstats1down", "BtagWeight_lfstats2up", "BtagWeight_lfstats2down",
+                 "BtagWeight_cferr1up", "BtagWeight_cferr1down", "BtagWeight_cferr2up", "BtagWeight_cferr2down"]
+    syst_forWeight = ["LHEScaleWeight", "LHEScaleWeight_MuRUp", "LHEScaleWeight_MuRDown", "LHEScaleWeight_MuFUp", "LHEScaleWeight_MuFDown", "Electron_SF", "Electron_SFerr", "MuonID_SF", "MuonID_SFerr", "MuonISO_SF", "MuonISO_SFerr", "Trigger_SF", "puWeight", "puWeightUp", "puWeightDown", "BtagWeight"]
+    #name for histogram
+    syst_name = ["", "MuRDown", "MuFDown", "MuFUp", "MuRUp", "ElSFUp", "ElSFDown", "MuIDUp", "MuIDDown", "MuISOUp", "MuISODown", "PUUp", "PUDown", "BtagJESUp", "BtagJESDown", "BtagLFUp", "BtagLFDown", "BtagHFUp", "BtagHFDown", "BtagHFStats1Up", "BtagHFStats1Down", "BtagHFStats2Up", "BtagHFStats2Down", "BtagLFStats1Up", "BtagLFStats1Down", "BtagLFStats2Up", "BtagLFStats2Down", "BtagCQErr1Up", "BtagCQErr1Down", "BtagCQErr2Up", "BtagCQErr2Down"]
+    #weight from origin: "LHEScaleWeight[4]*genWeight/abs(genWeight)*puWeight*BtagWeight*Trigger_SF*Electron_SF*MuonID_SF*MuonISO_SF
+    #ElSF up/down -> up/down: Electron_SF +- Electron_SFerr
+    #MuID up/down -> up/down: MuonID_SF +- MuonID_SFerr
+    #MuISO up/down -> up/down: MuonISO_SF +- MuonISO_SFerr
+    #syst_lepSF_name = ["ElSFUp", "ElSFDown", "MuIDUp", "MuIDDown", "MuISOUp", "MuISODown"]
+    #MuR up / down -> LHEScaleWeight[7] / [1]
+    #MuF up/down -> LHEScaleWeight[5] / [3]
+    #syst_theory_name = ["MuRUp", "MuRDown", "MuFUp", "MuFDown"]
+
+    channels = ["TTZct", "TTZut", "STZct", "STZut"]
+    modes = ["ElElEl", "MuElEl", "ElMuMu", "MuMuMu"]
+
+    procInfo = yaml.load(open(rootDir+"config/grouping.yaml").read())["processes"]
+    crosssection = yaml.load(open(rootDir+"config/crosssection.yaml").read())["crosssection"]
+    entries = yaml.load(open(rootDir+"config/crosssection.yaml").read())["Entries"]
+    datasetInfo = {}
+    for f in glob(rootDir+"config/datasets/MC*16*.yaml"):
+        if 'dataset' not in datasetInfo: datasetInfo["dataset"] = {}
+        datasetInfo["dataset"].update(yaml.load(open(f).read())["dataset"])
+    if not os.path.exists( os.path.join(rootDir, 'TMVA', 'shape') ):
+        os.makedirs(os.path.join(rootDir, 'TMVA', 'shape'))
+    #Number of MVA score shape bins
+    nbins = 10
+    for ch in channels:
+        outFileName = 'shape_%s' % ch
+        outFile = TFile.Open( os.path.join(rootDir, 'TMVA', 'shape', outFileName + '.root'), 'RECREATE' )
+        for mo in modes:
+            hist_data = TH1F(mo+"_"+"data_obs", "mva shape data", nbins, -1, 1)
+            for systjet in syst:
+                for proc in procInfo:
+                    #proc: DataElElEl, ... DataElMuMu, DataNPL..., DYJets, SingleTop, TTJets, STZct, ..., -> categories
+                    hmc_mva_syst_list = []
+                    if systjet == "origin":
+                        if proc == "TTZct" or proc == "TTZut" or proc == "STZct" or proc == "STZut":
+                            if proc == ch:
+                                hmc_jet = TH1F(mo+"_"+proc, "mva shape origin", nbins, -1, 1)
+                            else: continue
+                        else:
+                            hmc_jet = TH1F(mo+"_"+proc, "mva shape origin", nbins, -1, 1)
+                    else:
+                        if proc == "TTZct" or proc == "TTZut" or proc == "STZct" or proc == "STZut":
+                            if proc == ch:
+                                hmc_jet = TH1F(mo+"_"+proc+"_"+systjet, "mva shape", nbins, -1, 1)
+                            else: continue
+                        else:
+                            hmc_jet = TH1F(mo+"_"+proc+"_"+systjet, "mva shape origin", nbins, -1, 1)
+                    if systjet == "origin":
+                        for name in range(len(syst_name)):
+                            if name == 0: continue
+                            if proc == "TTZct" or proc == "TTZut" or proc == "STZct" or proc == "STZut":
+                                if proc == ch:
+                                    hmc_mva_syst = TH1F(mo+"_"+proc+"_"+syst_name[name], "mva shape %s" % syst_name[name], nbins, -1, 1)
+                                    hmc_mva_syst_list.append(hmc_mva_syst)
+                                else: continue
+                            else:
+                                hmc_mva_syst = TH1F(mo+"_"+proc+"_"+syst_name[name], "mva shape %s" % syst_name[name], nbins, -1, 1)
+                                hmc_mva_syst_list.append(hmc_mva_syst)
+
+                    for datasetGroup in procInfo[proc]['datasets']:
+                        #datasetGroup: datasets in each category
+                        #shape must be saved by each category.
+                        weight_mc = 1
+                        if "MC" in datasetGroup:
+                            # Read score file
+                            if proc == "TTZct" or proc == "TTZut" or proc == "STZct" or proc == "STZut":
+                                if proc == ch:
+                                    f_score = TFile.Open(os.path.join(dName, ch, mo+'_WZ_ZZ', systjet, 'score_TMVA_'+datasetGroup[7:]+'.root' ))
+                                else:
+                                    print "This MC category is not signal"
+                                    continue
+                            else:
+                                f_score = TFile.Open(os.path.join(dName, ch, mo+'_WZ_ZZ', systjet, 'score_TMVA_'+datasetGroup[7:]+'.root' ))
+                            score_tree = f_score.Get("Events")
+                            if systjet == "origin": score_tree_btag = f_score.Get("EventsBtag")
+
+                            print systjet+"_"+datasetGroup[7:]
+
+                            branches = {}
+                            for branch in score_tree.GetListOfBranches():
+                                branchName = branch.GetName()
+                                if branchName in ["MLScore", "nEvent"]:
+                                    branches[branchName] = array('f', [-999])
+                                    score_tree.SetBranchAddress(branchName, branches[branchName])
+                                if branchName in syst_forWeight:
+                                    branches[branchName] = array('f', [-999])
+                                    score_tree.SetBranchAddress(branchName, branches[branchName])
+                            branches_b = {}
+                            if systjet == "origin":
+                                for branch in score_tree_btag.GetListOfBranches():
+                                    branchName = branch.GetName()
+                                    if (systjet == "origin") and (branchName in syst_btagshape):
+                                        branches_b[branchName] = array('f', [-999])
+                                        score_tree_btag.SetBranchAddress(branchName, branches_b[branchName])
+
+                            xsec_num = 1.0
+                            for xsec in crosssection:
+                                for num in entries:
+                                    if num == "TT":
+                                        name = num + ".powheg"
+                                    else:
+                                        name = num
+                                    if datasetGroup[7:] == name and num == xsec:
+                                        xsec_num = (float(crosssection[xsec])/float(entries[num]))*35900
+                            print xsec_num
+
+
+                            totevent_score = score_tree.GetEntries()
+                            for i in xrange(totevent_score):
+                                score_tree.GetEntry(i)
+                                if systjet == "origin":
+                                    score_tree_btag.GetEntry(i)
+                                    genWeight = score_tree.genWeight
+                                    Trigger_SF = score_tree.Trigger_SF
+                                    for name in range(len(syst_name)):
+                                        if syst_name[name] == "MuRDown": LHEWeight = score_tree.LHEScaleWeight_MuRDown
+                                        elif syst_name[name] == "MuFDown": LHEWeight = score_tree.LHEScaleWeight_MuFDown
+                                        elif syst_name[name] == "MuFUp": LHEWeight = score_tree.LHEScaleWeight_MuFUp
+                                        elif syst_name[name] == "MuRUp": LHEWeight = score_tree.LHEScaleWeight_MuRUp
+                                        else: LHEWeight = score_tree.LHEScaleWeight
+
+                                        if syst_name[name] == "ElSFUp": Ele_SF = score_tree.Electron_SF + score_tree.Electron_SFerr
+                                        elif syst_name[name] == "ElSFDown": Ele_SF = score_tree.Electron_SF - score_tree.Electron_SFerr
+                                        else: Ele_SF = score_tree.Electron_SF
+
+                                        if syst_name[name] == "MuIDUp": MuID_SF = score_tree.MuonID_SF + score_tree.MuonID_SFerr
+                                        elif syst_name[name] == "MuIDDown": MuID_SF = score_tree.MuonID_SF - score_tree.MuonID_SFerr
+                                        else: MuID_SF = score_tree.MuonID_SF
+
+                                        if syst_name[name] == "MuISOUp": MuISO_SF = score_tree.MuonISO_SF + score_tree.MuonISO_SFerr
+                                        elif syst_name[name] == "MuISODown": MuISO_SF = score_tree.MuonISO_SF - score_tree.MuonISO_SFerr
+                                        else: MuISO_SF = score_tree.MuonISO_SF
+
+                                        if syst_name[name] == "PUUp": puWeight = score_tree.puWeightUp
+                                        elif syst_name[name] == "PUDown": puWeight = score_tree.puWeightDown
+                                        else: puWeight = score_tree.puWeight
+
+                                        if "JESUp" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_jesup
+                                        elif "JESDown" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_jesdown
+                                        elif "LFUp" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_lfup
+                                        elif "LFDown" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_lfdown
+                                        elif "HFUp" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_hfup
+                                        elif "HFDown" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_hfdown
+                                        elif "HFStats1Up" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_hfstats1up
+                                        elif "HFStats1Down" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_hfstats1down
+                                        elif "HFStats2Up" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_hfstats2up
+                                        elif "HFStats2Down" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_hfstats2down
+                                        elif "LFStats1Up" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_lfstats1up
+                                        elif "LFStats1Down" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_lfstats1down
+                                        elif "LFStats2Up" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_lfstats2up
+                                        elif "LFStats2Down" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_lfstats2down
+                                        elif "CQErr1Up" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_cferr1up
+                                        elif "CQErr1Down" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_cferr1down
+                                        elif "CQErr2Up" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_cferr2up
+                                        elif "CQErr2Down" in syst_name[name]: btagWeight = score_tree_btag.BtagWeight_cferr2down
+                                        else: btagWeight = score_tree.BtagWeight
+
+                                        weight_mc *= LHEWeight*genWeight/abs(genWeight)*puWeight*btagWeight*Trigger_SF*Ele_SF*MuID_SF*MuISO_SF*xsec_num
+                                        if proc == "TTZct" or proc == "TTZut" or proc == "STZct" or proc == "STZut":
+                                            if proc in hmc_jet.GetName(): #for signal MC
+                                                if syst_name[name] == "": hmc_jet.Fill(score_tree.MLScore, weight_mc)
+                                                elif syst_name[name] != "" and name != 0:
+                                                    for hist in hmc_mva_syst_list:
+                                                        if syst_name[name] in hist.GetName():
+                                                            hist.Fill(score_tree.MLScore, weight_mc)
+                                                        else: continue
+                                                else: continue
+                                            else: continue
+                                        else:
+                                            if syst_name[name] == "": hmc_jet.Fill(score_tree.MLScore, weight_mc)
+                                            elif syst_name[name] != "" and name != 0:
+                                                for hist in hmc_mva_syst_list:
+                                                    if syst_name[name] in hist.GetName():
+                                                        hist.Fill(score_tree.MLScore, weight_mc)
+                                                    else: continue
+                                            else: continue
+                                        weight_mc = 1
+                                elif systjet != "origin":
+                                    genWeight = score_tree.genWeight
+                                    Trigger_SF = score_tree.Trigger_SF
+                                    LHEWeight = score_tree.LHEScaleWeight
+                                    Ele_SF = score_tree.Electron_SF
+                                    MuID_SF = score_tree.MuonID_SF
+                                    MuISO_SF = score_tree.MuonISO_SF
+                                    puWeight = score_tree.puWeight
+                                    btagWeight = score_tree.BtagWeight
+                                    weight_mc *= LHEWeight*genWeight/abs(genWeight)*puWeight*btagWeight*Trigger_SF*Ele_SF*MuID_SF*MuISO_SF*xsec_num
+                                    if proc == "TTZct" or proc == "TTZut" or proc == "STZct" or proc == "STZut":
+                                        if proc in hmc_jet.GetName(): hmc_jet.Fill(score_tree.MLScore, weight_mc)
+                                    else: hmc_jet.Fill(score_tree.MLScore, weight_mc)
+                                    weight_mc = 1
+                                else:
+                                    print "!!Fail!!"
+                            f_score.Close()
+
+                        elif "Run" in datasetGroup:
+                            if ("Data" in procInfo[proc]['title']) and mo == procInfo[proc]['modes'][0] and ("NPL" not in procInfo[proc]['modes'][0]) and systjet=="origin":
+                                f_score = TFile.Open(os.path.join(dName, ch, mo+'_WZ_ZZ', systjet, 'score_TMVA_'+datasetGroup[8:]+'.root'))
+                                score_tree = f_score.Get("Events")
+                                totevent_score = score_tree.GetEntries()
+                                print datasetGroup[8:]
+                                branches = {}
+                                for branch in score_tree.GetListOfBranches():
+                                    branchName = branch.GetName()
+                                    if branchName in ["MLScore", "nEvent"]:
+                                        branches[branchName] = array('f', [-999])
+                                        score_tree.SetBranchAddress(branchName, branches[branchName])
+
+                                for i in xrange(totevent_score):
+                                    score_tree.GetEntry(i)
+                                    hist_data.Fill(score_tree.MLScore)
+                                f_score.Close()
+                    outFile.cd()
+                    if not "Data" in proc:
+                        hmc_jet.Write()
+                        for hist in hmc_mva_syst_list:
+                            hist.Write()
+                    if "Data" in proc and mo == procInfo[proc]['modes'][0] and ("NPL" not in procInfo[proc]['modes'][0]) and systjet=="origin":
+                        hist_data.Write()
+        outFile.Close()

--- a/TopAnalysis/test/fcncTriLepton/TMVA/job_TMVAClassification.sh
+++ b/TopAnalysis/test/fcncTriLepton/TMVA/job_TMVAClassification.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+channel=( "TTZct TTZut STZct STZut" )
+#channel=( "STZct STZut" )
+mode=( "ElElEl MuElEl ElMuMu MuMuMu" )
+
+for ch in ${channel[@]}; do
+    category=$(echo ${ch} | cut -c1-2)
+    for mo in ${mode[@]}; do
+        #nohup python TMVAClassification.py -C ${ch} -M ${mo} -m BDTG_${category} -o ${ch}_${mo}_WZ_ZZ_Tr7Te3 > log_${ch}_${mo}_WZ_ZZ_Tr7Te3.txt &
+        nohup python TMVAClassification.py -C ${ch} -M ${mo} -m BDTG_${category} -o ${ch}_${mo}_tightjet > log_${ch}_${mo}_tightjet.txt &
+    done
+done

--- a/TopAnalysis/test/fcncTriLepton/TMVA/job_TMVAEvaluation_bdt.sh
+++ b/TopAnalysis/test/fcncTriLepton/TMVA/job_TMVAEvaluation_bdt.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+channel=( "TTZct TTZut STZct STZut" )
+mode=( "ElElEl MuElEl ElMuMu MuMuMu" )
+
+for ch in ${channel[@]}; do
+    for mo in ${mode[@]}; do
+        nohup python TMVAEvaluation_bdt.py ${ch} ${mo} > log_eval_${ch}_${mo}.txt &
+    done
+done
+

--- a/TopAnalysis/test/fcncTriLepton/TMVA/job_TMVAEvaluation_btagWeight.sh
+++ b/TopAnalysis/test/fcncTriLepton/TMVA/job_TMVAEvaluation_btagWeight.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+channel=( "TTZct TTZut STZct STZut" )
+mode=( "ElElEl MuElEl ElMuMu MuMuMu" )
+
+for ch in ${channel[@]}; do
+    for mo in ${mode[@]}; do
+        nohup python TMVAEvaluation_btagWeight.py ${ch} ${mo} > log_eval_${ch}_${mo}_btagWeight.txt &
+    done
+done
+

--- a/TopAnalysis/test/fcncTriLepton/TMVA/shape_add.py
+++ b/TopAnalysis/test/fcncTriLepton/TMVA/shape_add.py
@@ -1,0 +1,91 @@
+#! /bin/env python
+
+import os, sys
+import yaml
+from glob import glob
+from ROOT import *
+
+processes_mapping = {
+    'others' : ['SingleTop', 'WW', 'TTH']
+}
+
+if __name__ == '__main__':
+    # Read input data
+    rootDir = '%s/src/TZWi/TopAnalysis/test/fcncTriLepton/' % os.environ["CMSSW_BASE"]
+    syst = ["origin", "jesUp", "jesDown", "jerUp", "jerDown"]
+    #name for histogram
+    syst_name = ["", "MuRDown", "MuFDown", "MuFUp", "MuRUp", "ElSFUp", "ElSFDown", "MuIDUp", "MuIDDown", "MuISOUp", "MuISODown", "PUUp", "PUDown", "BtagJESUp", "BtagJESDown", "BtagLFUp", "BtagLFDown", "BtagHFUp", "BtagHFDown", "BtagHFStats1Up", "BtagHFStats1Down", "BtagHFStats2Up", "BtagHFStats2Down", "BtagLFStats1Up", "BtagLFStats1Down", "BtagLFStats2Up", "BtagLFStats2Down", "BtagCQErr1Up", "BtagCQErr1Down", "BtagCQErr2Up", "BtagCQErr2Down"]
+
+    channels = ["TTZct", "TTZut", "STZct", "STZut"]
+    modes = ["ElElEl", "MuElEl", "ElMuMu", "MuMuMu"]
+
+    procInfo = yaml.load(open(rootDir+"config/grouping.yaml").read())["processes"]
+    crosssection = yaml.load(open(rootDir+"config/crosssection.yaml").read())["crosssection"]
+    entries = yaml.load(open(rootDir+"config/crosssection.yaml").read())["Entries"]
+    datasetInfo = {}
+    for f in glob(rootDir+"config/datasets/MC*16*.yaml"):
+        if 'dataset' not in datasetInfo: datasetInfo["dataset"] = {}
+        datasetInfo["dataset"].update(yaml.load(open(f).read())["dataset"])
+    if not os.path.exists( os.path.join(rootDir, 'TMVA', 'shape') ):
+        os.makedirs(os.path.join(rootDir, 'TMVA', 'shape'))
+    #Number of MVA score shape bins
+    nbins = 10
+    for ch in channels:
+        outFileName = 'add_shape_%s' % ch
+        outFile = TFile.Open( os.path.join(rootDir, 'TMVA', 'shape', outFileName + '.root'), 'RECREATE' )
+        f_shape = TFile.Open( os.path.join(rootDir, 'TMVA', 'shape', 'shape_' + ch + '.root') )
+        for mo in modes:
+           hist_list = []
+           no_overlap_hist_list = []
+           merge_hist_sys_list = []
+           merge_hist_jet_list = []
+           nbins = 10
+           for name in range(len(syst_name)):
+               if name == 0: continue
+               merge_hist_sys = TH1F(mo+"_others_" + syst_name[name], "mva shape %s" % syst_name[name], nbins, -1, 1)
+               merge_hist_sys_list.append(merge_hist_sys)
+           for jet_syst in syst:
+               if jet_syst == "origin": merge_hist_jet = TH1F(mo + "_others", "mva shape origin", nbins, -1, 1)
+               else: merge_hist_jet = TH1F(mo + "_others_" + jet_syst, "mva shape", nbins, -1, 1)
+               merge_hist_jet_list.append(merge_hist_jet)
+
+           for merge_name, origin_group in processes_mapping.items(): # merge_name: key, origin_group: value
+               for category in origin_group:
+                   for h_key in f_shape.GetListOfKeys(): #histogram name
+                       if mo not in h_key.GetName(): continue
+                       else:
+                           if category in h_key.GetName():
+                               for name in range(len(syst_name)):
+                                   if name == 0: continue
+                                   if h_key.GetName() == mo + "_" + category + "_" + syst_name[name]:
+                                       for merge_hist_sys in merge_hist_sys_list:
+                                           if mo + "_" + merge_name + "_" + syst_name[name] == merge_hist_sys.GetName():
+                                               print h_key.GetName()
+                                               hist = f_shape.Get(h_key.GetName())
+                                               merge_hist_sys.Add(hist)
+                               for jet_syst in syst:
+                                   for merge_hist_jet in merge_hist_jet_list:
+                                       if jet_syst == "origin" and h_key.GetName() == mo + "_" + category:
+                                           print h_key.GetName()
+                                           hist = f_shape.Get(h_key.GetName())
+                                           if merge_hist_jet.GetName() == mo + "_" + merge_name: merge_hist_jet.Add(hist)
+                                       elif jet_syst != "origin" and h_key.GetName() == mo + "_" + category + "_" + jet_syst:
+                                           print h_key.GetName()
+                                           hist = f_shape.Get(h_key.GetName())
+                                           if merge_hist_jet.GetName() == mo + "_" + merge_name + "_" + jet_syst: merge_hist_jet.Add(hist)
+                           else:
+                               hist = f_shape.Get(h_key.GetName())
+                               hist_list.append(hist)
+           for h in hist_list:
+               if h not in no_overlap_hist_list:
+                   no_overlap_hist_list.append(h)
+           outFile.cd()
+           for h in no_overlap_hist_list:
+               h.Write()
+           for merge_h in merge_hist_sys_list:
+               merge_h.Write()
+           for merge_h in merge_hist_jet_list:
+               merge_h.Write()
+        outFile.Close()
+
+

--- a/TopAnalysis/test/fcncTriLepton/TMVA/variables.py
+++ b/TopAnalysis/test/fcncTriLepton/TMVA/variables.py
@@ -1,0 +1,23 @@
+from ROOT import *
+import os
+
+#order does matter (order must be same to the ntuple)
+def input_TT_bdt(channel):
+    if channel == "TTZct" or channel == "TTZut":
+        # Define default variable first
+        var_list = ['Z_mass', 'W_MT',]
+        var_list.extend(['KinTopWb_mass', 'KinTopZq_mass',
+                         'MVAinput_bJ_DeepJetB', 'MVAinput_qJ_DeepJetB', 'MVAinput_bJ_pt',
+                         'MVAinput_bJqJ_dR', 'MVAinput_WLbJ_dPhi', 'MVAinput_WLqJ_dR', 'MVAinput_ZL1bJ_dR', 'MVAinput_ZL1qJ_dR',])
+
+    return var_list
+
+def input_ST_bdt(channel):
+    if channel == "STZct" or channel == "STZut":
+        # Define default variable first
+        var_list = ['Z_mass', 'TriLepton_WleptonZdPhi', 'TriLepton_WleptonZdR', 'W_MT',]
+        var_list.extend(['KinTopWb_pt', 'KinTopWb_phi',
+                        'MVAinput_WLZL1_dPhi', 'MVAinput_WLZL1_dR', 'MVAinput_bJ_DeepJetB',
+                        'MVAinput_WLbJ_dPhi', 'MVAinput_WLbJ_dR', 'MVAinput_ZL1bJ_dR',])
+
+    return var_list


### PR DESCRIPTION
This PR is contained about evaluating all samples with training results and get a shape that can be handled at the Higgs combine tool
* How to do training the sample ~ get a shape
(This comment might be added in more detailed or updating this comment by README)
$ ./job_TMVAClassification.sh
after the job is finished, training the sample is done
$ ./job_TMVAEvaluation_bdt.sh
after the job is finished, the 'score' directory is created which contain the score files
$ ./job_TMVAEvaluation_btagWeight.sh
after the job is finished, score files are updated that additionally have systematic branches about btag jet energy
$ python getShpae.py
after the job is finished, you can use the output(shape root files) when the fitting with the combine tool.
* The code of the bottom one is an additional process.
If you need to combine some of the MC categories for fitting, then run this code together after getting a shape!
$ python shape_add.py

From the evaluation code: 
When the branches are saved more than ~20 by once, then there was an error about cannot read the branches from the ntuple.
So, unfortunately, the evaluation code was divided into two parts; 
1. saving the scores & about systematic uncertainty branches except for btag jet energy part
2. saving the systematic uncertainty branches about btag jet energy part
